### PR TITLE
fix: route Subsonic + cover-art fetches through the http plugin

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,7 +8,13 @@
     "core:window:allow-set-decorations",
     "core:window:allow-is-decorated",
     "fs:default",
-    "http:default",
+    {
+      "identifier": "http:default",
+      "allow": [
+        { "url": "http://**" },
+        { "url": "https://**" }
+      ]
+    },
     "opener:default",
     "shell:default",
     "updater:default"

--- a/src/app.js
+++ b/src/app.js
@@ -591,7 +591,11 @@ const OpenSubsonicMapper = {
 const Api = {
   fetch: async (action, params = {}, signal = null) => {
     const url = await OpenSubsonicRouter.buildUrl(action, params);
-    const res = await fetch(url, signal ? { signal } : {});
+    // Use the http plugin (registered in main.rs) instead of the WebView's native
+    // fetch — plain http:// targets are blocked by WebKit's mixed-content rule from
+    // the secure WebView origin (tauri://localhost). The plugin routes through
+    // reqwest on the Rust side, where that restriction doesn't apply.
+    const res = await window.__TAURI__.http.fetch(url, signal ? { signal } : {});
     if (res.status === 401) { if (Store.Auth.isAuthed()) teardownApp(); throw new Error('Session Expired'); }
     if (!res.ok) throw new Error(`HTTP Error ${res.status}`);
     const json = await res.json();
@@ -747,7 +751,8 @@ const loadImage = async (img, coverId, signal) => {
   if (!promise) {
     promise = (async () => {
       const url = await OpenSubsonicRouter.buildUrl('getCoverArt', { id: coverId });
-      const res = await fetch(url, { signal });
+      // http plugin — see Api.fetch for the why.
+      const res = await window.__TAURI__.http.fetch(url, { signal });
       if (!res.ok) throw new Error('Cover art unavailable');
       const blob = await res.blob();
       const objUrl = URL.createObjectURL(blob);


### PR DESCRIPTION
## Problem

Firmium can't connect to a Subsonic/Navidrome server served over plain `http://` — e.g. a typical `http://localhost:4533` install. The login screen shows "Load failed" and the request never reaches the server. This affects the majority Navidrome setup, since Navidrome ships with TLS off by default and most users run it on localhost or behind an upstream reverse proxy.

## Root cause

The Tauri WebView on Linux is loaded from `tauri://localhost`. `wry` registers that scheme as **secure** in WebKitGTK (`wry/src/webkitgtk/web_context.rs` — `register_uri_scheme_as_secure`), so when `Api.fetch` in `src/app.js` calls `window.fetch()` against an `http://` URL, WebKit's mixed-content blocker silently aborts the request before it leaves the app. CSP allowing the URL doesn't help — mixed-content enforcement runs before CSP.

Same thing for cover-art image fetches in `loadImage`.

I verified by tailing `journalctl --user -u navidrome` while clicking Connect — Navidrome never sees the request.

## Fix

`tauri-plugin-http` is already a dependency, already initialized at `main.rs:249`, and already permitted via `"http:default"` in capabilities. Its `api-iife.js` is auto-injected because `withGlobalTauri: true` is set in `tauri.conf.json` — which means `window.__TAURI__.http.fetch(url, init)` is **already callable from JS today** with no bundler or import changes. It's a drop-in for `window.fetch` (same Request / Response / AbortSignal shape), but routed through `reqwest` on the Rust side where mixed-content doesn't apply.

So the patch is small:

1. **Swap two `fetch` call sites in `src/app.js`** — `Api.fetch` (Subsonic JSON) and `loadImage` (cover-art blob). No JS API change.
2. **Add the URL scope to `capabilities/default.json`** — `"http:default"` alone grants permission to *call* the plugin commands, but the plugin still rejects requests with `Error::UrlNotAllowed` unless the URL matches an `allow` pattern. The scope I added (`http://**` and `https://**`) matches firmium's existing CSP posture (`connect-src http://* https://*`); could be tightened later if a "fixed server host" setting ever lands.

## Out of scope (deliberately, but happy to extend)

- **`Api.scrobble`** at `src/app.js:649` also uses `window.fetch` and is affected by the same bug — HTTP users currently don't get scrobbles. It's a one-line change to migrate (just swap `fetch(url)` → `window.__TAURI__.http.fetch(url)`). Left out to keep this PR focused; happy to add if you'd prefer one PR.
- **Wikipedia (`en.wikipedia.org`) and lrclib (`lrclib.net`)** are already HTTPS, so mixed-content doesn't apply — no change needed.

## What I considered and rejected

- **Add custom Rust commands wrapping `reqwest`.** Works, but duplicates what `tauri-plugin-http` already provides, drops native `AbortSignal` support, and ignores the fact that you'd already wired the plugin in.
- **Switch the WebView origin to `http://` via `useHttpsScheme`** in Tauri config. That flag only affects Windows and Android per `tauri-utils/src/config.rs` — Linux uses `tauri://localhost` regardless.
- **Disable WebKit's mixed-content check via env var.** No documented `WebKitSettings` knob is exposed through webkit2gtk-4.1 in a way Tauri can plumb.

## Tested

Built against v1.5.0 + this patch, ran against Navidrome 0.61.2 (`openSubsonic: true`) on `http://localhost:4533`:

- Login + album browse
- Cover-art thumbnails populate
- `getLyricsBySongId` (Subsonic-side lyrics) works
- lrclib fallback works (was always HTTPS, unaffected)
- Audio streaming works (was already on the Rust side, unaffected)