### PR TITLE
Add favorites and Spotify-style home/player polish

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -32,6 +32,7 @@ Legend: ✅ supported — ❌ not available — (blank) = same as ✅
 |---|:---:|:---:|
 | Browse albums, artists, and genres | ✅ | ✅ |
 | Home screen — recently played, newest, and random albums | ✅ | ✅ |
+| Favorites — tap the heart on any song, album, or artist to favorite it; see everything you've favorited in one place, with a quick-access shortcut from the home screen | ✅ | ✅ |
 | Artist pages with photos and Last.fm biography | ✅ | ✅ |
 | Play button on artist page — instantly plays that artist's top tracks | ❌ | ✅ |
 | Album detail pages with full track list | ✅ | ✅ |

--- a/android/app/src/main/java/com/fossisawesome/firmium/audio/PlaybackController.kt
+++ b/android/app/src/main/java/com/fossisawesome/firmium/audio/PlaybackController.kt
@@ -354,6 +354,12 @@ class PlaybackController(
         }
     }
 
+    fun updateTrackStarred(songId: String, starred: Boolean) {
+        _state.update { s ->
+            s.copy(queue = s.queue.map { if (it.id == songId) it.copy(starred = starred) else it })
+        }
+    }
+
     // ── Settings ───────────────────────────────────────────────────────────────
 
     fun setRepeatMode(mode: String) {

--- a/android/app/src/main/java/com/fossisawesome/firmium/data/api/ApiClient.kt
+++ b/android/app/src/main/java/com/fossisawesome/firmium/data/api/ApiClient.kt
@@ -290,6 +290,36 @@ class ApiClient(private val auth: AuthManager) {
         } catch (_: Exception) { /* rating failures are non-fatal */ }
     }
 
+    // ── Favorites ──────────────────────────────────────────────────────────────
+
+    data class StarredResult(val artists: List<Artist>, val albums: List<Album>, val songs: List<Song>)
+
+    private fun starParams(songId: String?, albumId: String?, artistId: String?): Map<String, String> =
+        buildMap {
+            songId?.let { put("id", it) }
+            albumId?.let { put("albumId", it) }
+            artistId?.let { put("artistId", it) }
+        }
+
+    suspend fun star(songId: String? = null, albumId: String? = null, artistId: String? = null) {
+        fetch("star", starParams(songId, albumId, artistId))
+    }
+
+    suspend fun unstar(songId: String? = null, albumId: String? = null, artistId: String? = null) {
+        fetch("unstar", starParams(songId, albumId, artistId))
+    }
+
+    suspend fun getStarred(): StarredResult {
+        val data = fetch("getStarred2")
+        val root = data.getAsJsonObject("starred2")
+        fun list(key: String) = root?.getAsJsonArray(key)?.map { it.asJsonObject } ?: emptyList()
+        return StarredResult(
+            artists = list("artist").map { parseArtist(it) },
+            albums = list("album").map { parseAlbum(it) },
+            songs = list("song").map { parseSong(it) },
+        )
+    }
+
     // ── Playback reporting ────────────────────────────────────────────────────
 
     // Reports playback state/position via the playbackReport OpenSubsonic extension
@@ -592,6 +622,7 @@ class ApiClient(private val auth: AuthManager) {
             genres = genres,
             releaseType = releaseType,
             isCompilation = obj.optBoolean("isCompilation") ?: false,
+            starred = obj.get("starred")?.isJsonNull == false,
         )
     }
 
@@ -626,6 +657,7 @@ class ApiClient(private val auth: AuthManager) {
             bpm = obj.optInt("bpm"),
             userRating = obj.optInt("userRating"),
             averageRating = obj.optDouble("averageRating")?.takeIf { it > 0.0 },
+            starred = obj.get("starred")?.isJsonNull == false,
         )
     }
 

--- a/android/app/src/main/java/com/fossisawesome/firmium/data/model/Album.kt
+++ b/android/app/src/main/java/com/fossisawesome/firmium/data/model/Album.kt
@@ -16,4 +16,5 @@ data class Album(
     val isCompilation: Boolean,
     // Only populated after fetching album detail (getAlbum endpoint).
     val tracks: List<Song> = emptyList(),
+    val starred: Boolean = false,
 )

--- a/android/app/src/main/java/com/fossisawesome/firmium/data/model/Song.kt
+++ b/android/app/src/main/java/com/fossisawesome/firmium/data/model/Song.kt
@@ -29,6 +29,7 @@ data class Song(
     val bpm: Int?,
     val userRating: Int? = null,
     val averageRating: Double? = null,
+    val starred: Boolean = false,
 ) {
     // Builds a "FLAC · 96 kHz · 24-bit · 1411 kbps" style summary, omitting missing parts.
     fun formatTrackInfo(): String {

--- a/android/app/src/main/java/com/fossisawesome/firmium/ui/components/FavoriteButton.kt
+++ b/android/app/src/main/java/com/fossisawesome/firmium/ui/components/FavoriteButton.kt
@@ -1,0 +1,31 @@
+package com.fossisawesome.firmium.ui.components
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.fossisawesome.firmium.ui.theme.LocalFirmiumColors
+
+// Heart toggle for the Favorites feature — filled + accent-colored when starred,
+// outline + muted otherwise. Used on album/track/artist headers and the player.
+@Composable
+fun FavoriteButton(
+    starred: Boolean,
+    onToggle: () -> Unit,
+    modifier: Modifier = Modifier,
+    size: Dp = 24.dp,
+) {
+    val colors = LocalFirmiumColors.current
+    FirmiumIconButton(onClick = onToggle, modifier = modifier.size(size + 16.dp)) {
+        FirmiumIcon(
+            imageVector = if (starred) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
+            contentDescription = if (starred) "Remove from favorites" else "Add to favorites",
+            tint = if (starred) colors.accent else colors.muted,
+            modifier = Modifier.size(size),
+        )
+    }
+}

--- a/android/app/src/main/java/com/fossisawesome/firmium/ui/components/FullScreenPlayer.kt
+++ b/android/app/src/main/java/com/fossisawesome/firmium/ui/components/FullScreenPlayer.kt
@@ -87,6 +87,7 @@ fun FullScreenPlayer(
     onCreatePlaylistAndAdd: (name: String) -> Unit,
     onStartRadio: (() -> Unit)? = null,
     onRate: ((songId: String, rating: Int) -> Unit)? = null,
+    onToggleStar: () -> Unit = {},
     onAddToQueue: () -> Unit,
     onViewArtist: () -> Unit,
     onEqualizer: () -> Unit,
@@ -238,6 +239,7 @@ fun FullScreenPlayer(
                         onMoreOpen = { showMore = true },
                         statsExpanded = statsExpanded,
                         onToggleStats = { statsExpanded = !statsExpanded },
+                        onToggleStar = onToggleStar,
                         compact = true,
                     )
                 }
@@ -267,6 +269,7 @@ fun FullScreenPlayer(
                     onMoreOpen = { showMore = true },
                     statsExpanded = statsExpanded,
                     onToggleStats = { statsExpanded = !statsExpanded },
+                    onToggleStar = onToggleStar,
                     compact = false,
                 )
 
@@ -362,6 +365,7 @@ private fun PlayerControls(
     onMoreOpen: () -> Unit,
     statsExpanded: Boolean,
     onToggleStats: () -> Unit,
+    onToggleStar: () -> Unit = {},
     compact: Boolean,
 ) {
     val colors = LocalFirmiumColors.current
@@ -372,16 +376,19 @@ private fun PlayerControls(
         modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Text(
-            text = track.title,
-            fontFamily = LocalAppFontFamily.current,
-            fontSize = if (compact) 16.sp else 20.sp,
-            fontWeight = FontWeight.Bold,
-            color = colors.text,
-            textAlign = TextAlign.Center,
-            maxLines = 1,
-            modifier = Modifier.basicMarquee(),
-        )
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(
+                text = track.title,
+                fontFamily = LocalAppFontFamily.current,
+                fontSize = if (compact) 16.sp else 20.sp,
+                fontWeight = FontWeight.Bold,
+                color = colors.text,
+                textAlign = TextAlign.Center,
+                maxLines = 1,
+                modifier = Modifier.basicMarquee().weight(1f, fill = false),
+            )
+            FavoriteButton(starred = track.starred, onToggle = onToggleStar, size = 20.dp)
+        }
         Spacer(Modifier.height(6.dp))
         Text(
             text = track.displayArtist ?: track.artist,

--- a/android/app/src/main/java/com/fossisawesome/firmium/ui/components/PlayerBar.kt
+++ b/android/app/src/main/java/com/fossisawesome/firmium/ui/components/PlayerBar.kt
@@ -32,10 +32,11 @@ fun PlayerBar(
     onNext: () -> Unit,
     onShuffleToggle: () -> Unit,
     onRepeatCycle: () -> Unit,
+    onToggleStar: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     if (LocalUiTheme.current == "spotify") {
-        PlayerBarSpotify(state, coverUrl, onBarClick, onPlayPause, onNext, modifier)
+        PlayerBarSpotify(state, coverUrl, onBarClick, onPlayPause, onNext, onToggleStar, modifier)
     } else {
         PlayerBarDefault(state, coverUrl, onBarClick, onPlayPause, onNext, onShuffleToggle, onRepeatCycle, modifier)
     }
@@ -159,6 +160,7 @@ private fun PlayerBarSpotify(
     onBarClick: () -> Unit,
     onPlayPause: () -> Unit,
     onNext: () -> Unit,
+    onToggleStar: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val track = state.currentTrack ?: return
@@ -209,6 +211,7 @@ private fun PlayerBarSpotify(
                     overflow = TextOverflow.Ellipsis,
                 )
             }
+            FavoriteButton(starred = track.starred, onToggle = onToggleStar, size = 16.dp)
             Spacer(Modifier.width(4.dp))
             FirmiumIconButton(onClick = onPlayPause, modifier = Modifier.size(44.dp)) {
                 FirmiumIcon(

--- a/android/app/src/main/java/com/fossisawesome/firmium/ui/navigation/AppNavGraph.kt
+++ b/android/app/src/main/java/com/fossisawesome/firmium/ui/navigation/AppNavGraph.kt
@@ -274,6 +274,7 @@ fun AppNavGraph(
             Brush.verticalGradient(listOf(colors.bg, colors.surface))
         )) {
             val homeState by libraryViewModel.homeState.collectAsStateWithLifecycle()
+            val favoritesState by libraryViewModel.favoritesState.collectAsStateWithLifecycle()
             val albumListState by libraryViewModel.albumListState.collectAsStateWithLifecycle()
             val artistListState by libraryViewModel.artistListState.collectAsStateWithLifecycle()
             val albumDetailState by libraryViewModel.albumDetailState.collectAsStateWithLifecycle()
@@ -297,6 +298,25 @@ fun AppNavGraph(
                         onAlbumClick = { navController.navigate("album/$it") },
                         onArtistClick = { navController.navigate("artist/$it") },
                         onRefresh = { libraryViewModel.loadHome() },
+                        onFavoritesClick = { navController.navigate("favorites") },
+                    )
+                }
+                composable(
+                    "favorites",
+                    enterTransition = detailEnterTransition,
+                    exitTransition = detailExitTransition,
+                    popEnterTransition = detailPopEnterTransition,
+                    popExitTransition = detailPopExitTransition,
+                ) {
+                    FavoritesScreen(
+                        state = favoritesState,
+                        coverUrlFor = coverUrl,
+                        onLoad = { libraryViewModel.loadFavorites() },
+                        onAlbumClick = { navController.navigate("album/$it") },
+                        onArtistClick = { navController.navigate("artist/$it") },
+                        onPlaySong = { song -> playerViewModel.playAt(listOf(song), 0) },
+                        onToggleSongStar = { libraryViewModel.toggleSongStar(it) },
+                        onBack = { navController.popBackStack() },
                     )
                 }
                 composable("mix") {
@@ -354,6 +374,8 @@ fun AppNavGraph(
                             { album -> { base(album)().also { if (it.isSuccess) libraryViewModel.refreshAlbumDownloaded() } } }
                         },
                         onArtistClick = { navController.navigate("artist/$it") },
+                        onToggleAlbumStar = { libraryViewModel.toggleAlbumStar(it) },
+                        onToggleSongStar = { libraryViewModel.toggleSongStar(it) },
                         onBack = { navController.popBackStack() },
                     )
                 }
@@ -593,6 +615,7 @@ fun AppNavGraph(
                 onPlayPause = { playerViewModel.togglePlayPause() },
                 onNext = { playerViewModel.skipToNext() },
                 onShuffleToggle = { playerViewModel.toggleShuffle() },
+                onToggleStar = { playerViewModel.toggleCurrentTrackStar() },
                 onRepeatCycle = {
                     // Cycle: none → all (repeat forever) → one (repeat once) → none
                     playerViewModel.setRepeatMode(when (playerState.repeatMode) {
@@ -673,6 +696,7 @@ fun AppNavGraph(
             },
             onStartRadio = { playerState.currentTrack?.let { playerViewModel.startRadio(it) } },
             onRate = { songId, rating -> playerViewModel.setRating(songId, rating) },
+            onToggleStar = { playerViewModel.toggleCurrentTrackStar() },
             onAddToQueue = { playerState.currentTrack?.let { playerViewModel.addToQueue(it) } },
             onViewArtist = {
                 playerState.currentTrack?.artistId?.takeIf { it.isNotBlank() }?.let {

--- a/android/app/src/main/java/com/fossisawesome/firmium/ui/screens/AlbumDetailScreen.kt
+++ b/android/app/src/main/java/com/fossisawesome/firmium/ui/screens/AlbumDetailScreen.kt
@@ -47,6 +47,8 @@ fun AlbumDetailScreen(
     onDownloadTrack: ((Song) -> suspend () -> Result<Unit>)? = null,
     onDownloadAlbum: ((com.fossisawesome.firmium.data.model.Album) -> suspend () -> Result<Unit>)? = null,
     onArtistClick: (String) -> Unit = {},
+    onToggleAlbumStar: (String) -> Unit = {},
+    onToggleSongStar: (Song) -> Unit = {},
     onBack: () -> Unit,
 ) {
     LaunchedEffect(albumId) { onLoad(albumId) }
@@ -122,6 +124,7 @@ fun AlbumDetailScreen(
                                     Text(meta, fontSize = 12.sp, fontFamily = LocalAppFontFamily.current, color = colors.muted)
                                     Spacer(Modifier.height(10.dp))
                                     Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                                        FavoriteButton(starred = album.starred, onToggle = { onToggleAlbumStar(album.id) }, size = 20.dp)
                                         if (onDownloadAlbum != null) {
                                             DownloadButton(
                                                 onDownload = onDownloadAlbum.invoke(album),
@@ -214,6 +217,7 @@ fun AlbumDetailScreen(
                             onAddClick = { pendingSong = song },
                             onDownloadClick = onDownloadTrack?.invoke(song),
                             isDownloaded = song.id in state.downloadedSongIds,
+                            onToggleStar = { onToggleSongStar(song) },
                         )
                         FirmiumDivider()
                     }
@@ -252,6 +256,7 @@ private fun AlbumTrackRow(
     onAddClick: () -> Unit,
     onDownloadClick: (suspend () -> Result<Unit>)? = null,
     isDownloaded: Boolean = false,
+    onToggleStar: () -> Unit = {},
 ) {
     val colors = LocalFirmiumColors.current
     Row(
@@ -283,6 +288,7 @@ private fun AlbumTrackRow(
             }
         }
         Text(formatDuration(track.duration), fontSize = 11.sp, fontFamily = LocalAppFontFamily.current, color = colors.muted)
+        FavoriteButton(starred = track.starred, onToggle = onToggleStar, size = 18.dp)
         if (onDownloadClick != null) {
             DownloadButton(onDownload = onDownloadClick, buttonSize = 32.dp, iconSize = 16.dp,
                 initiallyDownloaded = isDownloaded)
@@ -307,6 +313,7 @@ fun TrackRow(
     canMoveUp: Boolean = false,
     canMoveDown: Boolean = false,
     onRemove: (() -> Unit)? = null,
+    onToggleStar: (() -> Unit)? = null,
 ) {
     val colors = LocalFirmiumColors.current
     Row(
@@ -335,6 +342,9 @@ fun TrackRow(
         }
         Spacer(Modifier.width(8.dp))
         Text(formatDuration(track.duration), fontSize = 11.sp, fontFamily = LocalAppFontFamily.current, color = colors.muted)
+        if (onToggleStar != null) {
+            FavoriteButton(starred = track.starred, onToggle = onToggleStar, size = 18.dp)
+        }
         if (onDownloadClick != null) {
             DownloadButton(onDownload = onDownloadClick, buttonSize = 32.dp, iconSize = 16.dp,
                 initiallyDownloaded = isDownloaded)

--- a/android/app/src/main/java/com/fossisawesome/firmium/ui/screens/FavoritesScreen.kt
+++ b/android/app/src/main/java/com/fossisawesome/firmium/ui/screens/FavoritesScreen.kt
@@ -1,0 +1,122 @@
+package com.fossisawesome.firmium.ui.screens
+import com.fossisawesome.firmium.ui.theme.LocalAppFontFamily
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.background
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.fossisawesome.firmium.data.model.Album
+import com.fossisawesome.firmium.data.model.Artist
+import com.fossisawesome.firmium.data.model.Song
+import com.fossisawesome.firmium.ui.components.*
+import com.fossisawesome.firmium.ui.theme.LocalFirmiumColors
+import com.fossisawesome.firmium.viewmodel.FavoritesState
+
+@Composable
+fun FavoritesScreen(
+    state: FavoritesState,
+    coverUrlFor: (String?) -> String?,
+    onLoad: () -> Unit,
+    onAlbumClick: (String) -> Unit,
+    onArtistClick: (String) -> Unit,
+    onPlaySong: (Song) -> Unit,
+    onToggleSongStar: (Song) -> Unit,
+    onBack: () -> Unit,
+) {
+    LaunchedEffect(Unit) { onLoad() }
+    val colors = LocalFirmiumColors.current
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        FirmiumDetailHeader(title = "Favorites", onBack = onBack)
+        when {
+            state.isLoading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                FirmiumSpinner(color = colors.accent, modifier = Modifier.size(24.dp))
+            }
+            state.error != null -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text(state.error, color = colors.error, fontFamily = LocalAppFontFamily.current, fontSize = 13.sp)
+            }
+            state.artists.isEmpty() && state.albums.isEmpty() && state.songs.isEmpty() -> {
+                Box(Modifier.fillMaxSize().padding(32.dp), contentAlignment = Alignment.Center) {
+                    Text(
+                        "No favorites yet — tap the heart on any song, album, or artist.",
+                        color = colors.muted, fontFamily = LocalAppFontFamily.current, fontSize = 13.sp,
+                    )
+                }
+            }
+            else -> LazyColumn(contentPadding = PaddingValues(bottom = 32.dp)) {
+                if (state.albums.isNotEmpty()) {
+                    item {
+                        SectionTitle("Albums")
+                        LazyRow(contentPadding = PaddingValues(horizontal = 16.dp), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                            items(state.albums, key = { it.id }) { album -> FavoriteAlbumCard(album, coverUrlFor(album.coverArt), onAlbumClick) }
+                        }
+                        Spacer(Modifier.height(24.dp))
+                    }
+                }
+                if (state.artists.isNotEmpty()) {
+                    item {
+                        SectionTitle("Artists")
+                        LazyRow(contentPadding = PaddingValues(horizontal = 16.dp), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                            items(state.artists, key = { it.id }) { artist -> FavoriteArtistChip(artist, onArtistClick) }
+                        }
+                        Spacer(Modifier.height(24.dp))
+                    }
+                }
+                if (state.songs.isNotEmpty()) {
+                    item { SectionTitle("Songs") }
+                    items(state.songs, key = { it.id }) { song ->
+                        TrackRow(
+                            track = song,
+                            index = null,
+                            isCurrentlyPlaying = false,
+                            onClick = { onPlaySong(song) },
+                            onToggleStar = { onToggleSongStar(song) },
+                        )
+                        FirmiumDivider()
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionTitle(title: String) {
+    Text(
+        title, fontSize = 18.sp, fontWeight = FontWeight.Bold,
+        fontFamily = LocalAppFontFamily.current, color = LocalFirmiumColors.current.text,
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+    )
+}
+
+@Composable
+private fun FavoriteAlbumCard(album: Album, coverUrl: String?, onClick: (String) -> Unit) {
+    val colors = LocalFirmiumColors.current
+    Column(modifier = Modifier.width(130.dp).clickable { onClick(album.id) }, verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        CoverImage(url = coverUrl, contentDescription = album.name, modifier = Modifier.size(130.dp).clip(RoundedCornerShape(10.dp)).background(colors.surface2))
+        Text(album.name, fontSize = 12.sp, fontWeight = FontWeight.Bold, fontFamily = LocalAppFontFamily.current, color = colors.text, maxLines = 1)
+        Text(album.artist, fontSize = 11.sp, fontFamily = LocalAppFontFamily.current, color = colors.muted, maxLines = 1)
+    }
+}
+
+@Composable
+private fun FavoriteArtistChip(artist: Artist, onClick: (String) -> Unit) {
+    val colors = LocalFirmiumColors.current
+    Box(
+        modifier = Modifier.clip(RoundedCornerShape(999.dp)).background(colors.surface2)
+            .clickable { onClick(artist.id) }.padding(horizontal = 16.dp, vertical = 10.dp),
+    ) {
+        Text(artist.name, fontSize = 13.sp, fontFamily = LocalAppFontFamily.current, color = colors.text)
+    }
+}

--- a/android/app/src/main/java/com/fossisawesome/firmium/ui/screens/HomeScreen.kt
+++ b/android/app/src/main/java/com/fossisawesome/firmium/ui/screens/HomeScreen.kt
@@ -10,6 +10,11 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.outlined.Album
+import androidx.compose.material.icons.outlined.People
+import androidx.compose.material.icons.outlined.Radio
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -36,6 +41,8 @@ fun HomeScreen(
     onAlbumClick: (String) -> Unit,
     onArtistClick: (String) -> Unit,
     onRefresh: () -> Unit,
+    onFavoritesClick: () -> Unit = {},
+    onExploreNavigate: (String) -> Unit = {},
 ) {
     LaunchedEffect(Unit) { onRefresh() }
 
@@ -54,8 +61,13 @@ fun HomeScreen(
 
         Spacer(Modifier.height(8.dp))
 
-        if (spotify && state.recentAlbums.isNotEmpty()) {
-            HomeQuickAccess(state.recentAlbums, coverUrlFor, onAlbumClick)
+        if (spotify) {
+            ExploreChips(onNavigate = onExploreNavigate)
+            Spacer(Modifier.height(20.dp))
+        }
+
+        if (spotify) {
+            HomeQuickAccess(state.recentAlbums, coverUrlFor, onAlbumClick, onFavoritesClick)
             Spacer(Modifier.height(24.dp))
         }
 
@@ -125,36 +137,100 @@ private fun HomeGreeting(username: String) {
 
 // Spotify home's "quick access" grid: a 2-column grid of small horizontal cards
 // (square art + bold label) for recently played albums, shown above the shelves —
-// Spotify's most recognizable home pattern.
+// Spotify's most recognizable home pattern. Favorites is always the first tile.
 @Composable
-private fun HomeQuickAccess(albums: List<Album>, coverUrlFor: (String?) -> String?, onAlbumClick: (String) -> Unit) {
+private fun HomeQuickAccess(albums: List<Album>, coverUrlFor: (String?) -> String?, onAlbumClick: (String) -> Unit, onFavoritesClick: () -> Unit) {
     val colors = LocalFirmiumColors.current
+    val rest = albums.take(5)
+    val rows = (listOf<Album?>(null) + rest).chunked(2)
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        albums.take(6).chunked(2).forEach { row ->
+        rows.forEach { row ->
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 row.forEach { album ->
-                    Row(
-                        modifier = Modifier.weight(1f).clip(RoundedCornerShape(6.dp))
-                            .background(colors.surface)
-                            .clickable { onAlbumClick(album.id) },
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                    ) {
-                        CoverImage(
-                            url = coverUrlFor(album.coverArt),
-                            contentDescription = album.name,
-                            modifier = Modifier.size(56.dp).clip(RoundedCornerShape(6.dp))
-                                .background(colors.surface2),
-                        )
-                        Text(
-                            album.name, fontSize = 13.sp, fontWeight = FontWeight.Bold,
-                            fontFamily = LocalAppFontFamily.current, color = colors.text,
-                            maxLines = 1, overflow = TextOverflow.Ellipsis,
-                            modifier = Modifier.padding(end = 12.dp),
-                        )
+                    if (album == null) {
+                        Row(
+                            modifier = Modifier.weight(1f).clip(RoundedCornerShape(6.dp))
+                                .background(colors.surface)
+                                .clickable { onFavoritesClick() },
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            Box(
+                                modifier = Modifier.size(56.dp).clip(RoundedCornerShape(6.dp)).background(colors.surface2),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                FirmiumIcon(
+                                    imageVector = Icons.Default.Favorite,
+                                    contentDescription = null,
+                                    tint = colors.accent,
+                                    modifier = Modifier.size(24.dp),
+                                )
+                            }
+                            Text(
+                                "Favorites", fontSize = 13.sp, fontWeight = FontWeight.Bold,
+                                fontFamily = LocalAppFontFamily.current, color = colors.text,
+                                modifier = Modifier.padding(end = 12.dp),
+                            )
+                        }
+                    } else {
+                        Row(
+                            modifier = Modifier.weight(1f).clip(RoundedCornerShape(6.dp))
+                                .background(colors.surface)
+                                .clickable { onAlbumClick(album.id) },
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            CoverImage(
+                                url = coverUrlFor(album.coverArt),
+                                contentDescription = album.name,
+                                modifier = Modifier.size(56.dp).clip(RoundedCornerShape(6.dp))
+                                    .background(colors.surface2),
+                            )
+                            Text(
+                                album.name, fontSize = 13.sp, fontWeight = FontWeight.Bold,
+                                fontFamily = LocalAppFontFamily.current, color = colors.text,
+                                maxLines = 1, overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.padding(end = 12.dp),
+                            )
+                        }
                     }
                 }
                 if (row.size == 1) Spacer(Modifier.weight(1f))
+            }
+        }
+    }
+}
+
+// "Explore" pill row — quick shortcuts to Albums/Artists/Radio. Desktop skips this
+// since its permanent sidebar already exposes these destinations; Android's bottom
+// nav does too, but this mirrors the reference app's home-screen quick links.
+private data class ExploreDest(val route: String, val label: String, val icon: androidx.compose.ui.graphics.vector.ImageVector)
+
+private val EXPLORE_DESTS = listOf(
+    ExploreDest("music", "Albums", Icons.Outlined.Album),
+    ExploreDest("artists", "Artists", Icons.Outlined.People),
+    ExploreDest("mix", "Radio", Icons.Outlined.Radio),
+)
+
+@Composable
+private fun ExploreChips(onNavigate: (String) -> Unit) {
+    val colors = LocalFirmiumColors.current
+    LazyRow(
+        contentPadding = PaddingValues(end = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        items(EXPLORE_DESTS) { dest ->
+            Row(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(999.dp))
+                    .background(colors.surface2)
+                    .clickable { onNavigate(dest.route) }
+                    .padding(horizontal = 14.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                FirmiumIcon(dest.icon, contentDescription = null, tint = colors.text, modifier = Modifier.size(16.dp))
+                Text(dest.label, fontSize = 13.sp, fontWeight = FontWeight.SemiBold, fontFamily = LocalAppFontFamily.current, color = colors.text)
             }
         }
     }

--- a/android/app/src/main/java/com/fossisawesome/firmium/viewmodel/LibraryViewModel.kt
+++ b/android/app/src/main/java/com/fossisawesome/firmium/viewmodel/LibraryViewModel.kt
@@ -10,6 +10,7 @@ import com.fossisawesome.firmium.data.local.LocalLibraryRepository
 import com.fossisawesome.firmium.data.model.Album
 import com.fossisawesome.firmium.data.model.Artist
 import com.fossisawesome.firmium.data.model.ArtistDetail
+import com.fossisawesome.firmium.data.model.Song
 import com.fossisawesome.firmium.data.toUserError
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
@@ -27,6 +28,15 @@ data class HomeState(
     val recentAlbums: List<Album> = emptyList(),
     val recentArtists: List<RecentArtist> = emptyList(),
     val randomAlbums: List<Album> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: String? = null,
+)
+
+// Favorites screen data — starred artists/albums/songs from getStarred2.
+data class FavoritesState(
+    val artists: List<Artist> = emptyList(),
+    val albums: List<Album> = emptyList(),
+    val songs: List<Song> = emptyList(),
     val isLoading: Boolean = false,
     val error: String? = null,
 )
@@ -93,6 +103,9 @@ class LibraryViewModel(app: Application) : AndroidViewModel(app) {
     private val _homeState = MutableStateFlow(HomeState())
     val homeState: StateFlow<HomeState> = _homeState.asStateFlow()
 
+    private val _favoritesState = MutableStateFlow(FavoritesState())
+    val favoritesState: StateFlow<FavoritesState> = _favoritesState.asStateFlow()
+
     private val _albumListState = MutableStateFlow(AlbumListState())
     val albumListState: StateFlow<AlbumListState> = _albumListState.asStateFlow()
 
@@ -149,6 +162,22 @@ class LibraryViewModel(app: Application) : AndroidViewModel(app) {
                     return@launch
                 }
                 _homeState.value = HomeState(error = e.toUserError().message)
+            }
+        }
+    }
+
+    fun loadFavorites(force: Boolean = false) {
+        if (!force && _favoritesState.value.albums.isNotEmpty()) return
+        if (_favoritesState.value.isLoading) return
+        _favoritesState.value = FavoritesState(isLoading = true)
+        viewModelScope.launch {
+            try {
+                val result = api.getStarred()
+                _favoritesState.value = FavoritesState(artists = result.artists, albums = result.albums, songs = result.songs)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _favoritesState.value = FavoritesState(error = e.toUserError().message)
             }
         }
     }
@@ -236,6 +265,51 @@ class LibraryViewModel(app: Application) : AndroidViewModel(app) {
             localLibrary.invalidate()
             val downloaded = localLibrary.downloadedIds(album.tracks)
             _albumDetailState.value = _albumDetailState.value.copy(downloadedSongIds = downloaded)
+        }
+    }
+
+    // Optimistically flips the starred flag on the loaded album detail, then
+    // fires the network call; reverts on failure.
+    fun toggleAlbumStar(albumId: String) {
+        val current = _albumDetailState.value.album ?: return
+        val newStarred = !current.starred
+        _albumDetailState.value = _albumDetailState.value.copy(album = current.copy(starred = newStarred))
+        viewModelScope.launch {
+            try {
+                if (newStarred) api.star(albumId = albumId) else api.unstar(albumId = albumId)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                val reverted = _albumDetailState.value.album ?: return@launch
+                _albumDetailState.value = _albumDetailState.value.copy(album = reverted.copy(starred = !newStarred))
+            }
+        }
+    }
+
+    fun toggleSongStar(song: Song) {
+        val newStarred = !song.starred
+        val current = _albumDetailState.value.album
+        if (current != null) {
+            _albumDetailState.value = _albumDetailState.value.copy(
+                album = current.copy(tracks = current.tracks.map { if (it.id == song.id) it.copy(starred = newStarred) else it }),
+            )
+        }
+        // Keep the Favorites list in sync: unstarring a song there should drop it immediately.
+        _favoritesState.value = _favoritesState.value.copy(
+            songs = if (newStarred) _favoritesState.value.songs.map { if (it.id == song.id) it.copy(starred = true) else it }
+                    else _favoritesState.value.songs.filterNot { it.id == song.id },
+        )
+        viewModelScope.launch {
+            try {
+                if (newStarred) api.star(songId = song.id) else api.unstar(songId = song.id)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                val reverted = _albumDetailState.value.album ?: return@launch
+                _albumDetailState.value = _albumDetailState.value.copy(
+                    album = reverted.copy(tracks = reverted.tracks.map { if (it.id == song.id) it.copy(starred = !newStarred) else it }),
+                )
+            }
         }
     }
 

--- a/android/app/src/main/java/com/fossisawesome/firmium/viewmodel/PlayerViewModel.kt
+++ b/android/app/src/main/java/com/fossisawesome/firmium/viewmodel/PlayerViewModel.kt
@@ -114,6 +114,17 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
         }
     }
 
+    // ── Favorites ──────────────────────────────────────────────────────────────
+
+    fun toggleCurrentTrackStar() {
+        val track = state.value.currentTrack ?: return
+        val newStarred = !track.starred
+        viewModelScope.launch {
+            if (newStarred) api.star(songId = track.id) else api.unstar(songId = track.id)
+            controller.updateTrackStarred(track.id, newStarred)
+        }
+    }
+
     // ── Lyrics ─────────────────────────────────────────────────────────────────
 
     fun openLyrics() { lyrics.open() }

--- a/backend/commands/local_library.rs
+++ b/backend/commands/local_library.rs
@@ -206,6 +206,7 @@ fn scan() -> Result<LocalLibraryCache, String> {
             track_info: format_track_info(&track_info_json),
             user_rating: None,
             average_rating: None,
+            starred: false,
         };
 
         songs_by_album.entry(album_id).or_default().push(song.clone());
@@ -235,6 +236,7 @@ fn scan() -> Result<LocalLibraryCache, String> {
             genres,
             year: album_year.get(album_id).copied().flatten(),
             is_compilation: false,
+            starred: false,
         };
         albums_by_artist.entry(artist_id).or_default().push(album.clone());
         albums.push(album);

--- a/backend/commands/mappers.rs
+++ b/backend/commands/mappers.rs
@@ -19,6 +19,7 @@ pub struct Album {
     pub genres: Option<serde_json::Value>,
     pub year: Option<u32>,
     pub is_compilation: bool,
+    pub starred: bool,
 }
 
 /// Mapped artist.
@@ -55,6 +56,7 @@ pub struct Song {
     pub track_info: Option<String>,
     pub user_rating: Option<u32>,
     pub average_rating: Option<f32>,
+    pub starred: bool,
 }
 
 impl Song {
@@ -146,6 +148,7 @@ fn map_album(a: &serde_json::Value) -> Album {
         genres: a.get("genres").cloned(),
         year: a.get("year").and_then(|v| v.as_u64()).map(|n| n as u32),
         is_compilation: a.get("isCompilation").and_then(|v| v.as_bool()).unwrap_or(false),
+        starred: a.get("starred").is_some_and(|v| !v.is_null()),
     }
 }
 
@@ -181,6 +184,7 @@ fn map_song(s: &serde_json::Value) -> Song {
         track_info: format_track_info(s),
         user_rating: s.get("userRating").and_then(|v| v.as_u64()).map(|n| n as u32),
         average_rating: s.get("averageRating").and_then(|v| v.as_f64()).map(|n| n as f32).filter(|&n| n > 0.0),
+        starred: s.get("starred").is_some_and(|v| !v.is_null()),
     }
 }
 
@@ -224,6 +228,31 @@ pub fn map_similar_matches(matches: Vec<serde_json::Value>) -> Vec<SimilarMatch>
             similarity: m.get("similarity").and_then(|v| v.as_f64()).unwrap_or(0.0),
         })
         .collect()
+}
+
+/// All items the user has starred, as returned by `getStarred2`.
+#[derive(serde::Serialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct Starred {
+    pub artists: Vec<Artist>,
+    pub albums: Vec<Album>,
+    pub songs: Vec<Song>,
+}
+
+/// Maps a raw `getStarred2` response body (the `subsonic-response` object) into a `Starred`.
+pub fn map_starred(body: &serde_json::Value) -> Starred {
+    let root = body.get("starred2");
+    let list = |key: &str| -> Vec<serde_json::Value> {
+        root.and_then(|r| r.get(key))
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default()
+    };
+    Starred {
+        artists: map_artists(list("artist")),
+        albums: map_albums(list("album")),
+        songs: map_songs(list("song")),
+    }
 }
 
 #[cfg(test)]
@@ -433,5 +462,49 @@ mod tests {
         let matches = map_similar_matches(vec![json!({})]);
         assert_eq!(matches[0].similarity, 0.0);
         assert_eq!(matches[0].song.id, "");
+    }
+
+    // --- starred ---
+
+    #[test]
+    fn map_albums_reads_starred_flag() {
+        let starred = map_albums(vec![json!({ "starred": "2024-01-01T00:00:00.000Z" })]);
+        assert!(starred[0].starred);
+        let not_starred = map_albums(vec![json!({})]);
+        assert!(!not_starred[0].starred);
+    }
+
+    #[test]
+    fn map_songs_reads_starred_flag() {
+        let starred = map_songs(vec![json!({ "starred": "2024-01-01T00:00:00.000Z" })]);
+        assert!(starred[0].starred);
+        let not_starred = map_songs(vec![json!({})]);
+        assert!(!not_starred[0].starred);
+    }
+
+    #[test]
+    fn map_starred_parses_artists_albums_songs() {
+        let body = json!({
+            "starred2": {
+                "artist": [{ "id": "ar1", "name": "Artist" }],
+                "album": [{ "id": "al1", "name": "Album" }],
+                "song": [{ "id": "s1", "title": "Song" }],
+            }
+        });
+        let starred = map_starred(&body);
+        assert_eq!(starred.artists.len(), 1);
+        assert_eq!(starred.artists[0].id, "ar1");
+        assert_eq!(starred.albums.len(), 1);
+        assert_eq!(starred.albums[0].id, "al1");
+        assert_eq!(starred.songs.len(), 1);
+        assert_eq!(starred.songs[0].id, "s1");
+    }
+
+    #[test]
+    fn map_starred_missing_starred2_returns_empty() {
+        let starred = map_starred(&json!({}));
+        assert!(starred.artists.is_empty());
+        assert!(starred.albums.is_empty());
+        assert!(starred.songs.is_empty());
     }
 }

--- a/backend/commands/subsonic.rs
+++ b/backend/commands/subsonic.rs
@@ -10,7 +10,7 @@
 
 use crate::commands::auth::generate_auth_params;
 use crate::commands::lyrics::{fetch_lrclib_lyrics, LyricLine, LyricsResult};
-use crate::commands::mappers::{map_albums, map_artists, map_similar_matches, map_songs, Album, Artist, SimilarMatch, Song};
+use crate::commands::mappers::{map_albums, map_artists, map_similar_matches, map_songs, map_starred, Album, Artist, SimilarMatch, Song, Starred};
 use crate::events::BackendEvent;
 use crate::state::{AppState, ConnectionState};
 use std::sync::Arc;
@@ -194,6 +194,7 @@ pub struct AlbumTracks {
     pub album_name: String,
     pub album_artist: String,
     pub cover_art_id: Option<String>,
+    pub starred: bool,
 }
 
 pub async fn get_album_tracks(state: Arc<AppState>, id: String) -> Result<AlbumTracks, crate::errors::UserError> {
@@ -205,6 +206,7 @@ pub async fn get_album_tracks(state: Arc<AppState>, id: String) -> Result<AlbumT
         album_name: album.get("name").or_else(|| album.get("title")).and_then(|v| v.as_str()).unwrap_or("Unknown Album").to_string(),
         album_artist: album.get("displayArtist").or_else(|| album.get("artist")).and_then(|v| v.as_str()).unwrap_or("Unknown Artist").to_string(),
         cover_art_id: album.get("coverArt").and_then(|v| v.as_str()).map(str::to_string),
+        starred: album.get("starred").is_some_and(|v| !v.is_null()),
     })
 }
 
@@ -545,6 +547,43 @@ pub async fn set_rating(state: Arc<AppState>, id: String, rating: u32) {
     if let Err(e) = subsonic_request(&state, "setRating", &params, true).await {
         eprintln!("Set rating failed: {}", e.message());
     }
+}
+
+/// Which entity a star/unstar call targets — Subsonic's `star`/`unstar` accept
+/// `id` (song), `albumId`, or `artistId` as separate query params.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StarKind {
+    Song,
+    Album,
+    Artist,
+}
+
+impl StarKind {
+    fn param(self) -> &'static str {
+        match self {
+            StarKind::Song => "id",
+            StarKind::Album => "albumId",
+            StarKind::Artist => "artistId",
+        }
+    }
+}
+
+/// Stars a song, album, or artist via the `star` endpoint.
+pub async fn star_item(state: Arc<AppState>, id: String, kind: StarKind) -> Result<(), crate::errors::UserError> {
+    subsonic_request(&state, "star", &[(kind.param(), id)], false).await?;
+    Ok(())
+}
+
+/// Unstars a song, album, or artist via the `unstar` endpoint.
+pub async fn unstar_item(state: Arc<AppState>, id: String, kind: StarKind) -> Result<(), crate::errors::UserError> {
+    subsonic_request(&state, "unstar", &[(kind.param(), id)], false).await?;
+    Ok(())
+}
+
+/// Fetches every starred artist/album/song via `getStarred2`.
+pub async fn get_starred(state: Arc<AppState>) -> Result<Starred, crate::errors::UserError> {
+    let body = subsonic_request(&state, "getStarred2", &[], false).await?;
+    Ok(map_starred(&body))
 }
 
 /// Reports playback state/position via the `playbackReport` extension. No-op if

--- a/desktop/src/app/cover.rs
+++ b/desktop/src/app/cover.rs
@@ -66,6 +66,44 @@ impl App {
         }
     }
 
+    /// Whether the given id is currently starred, checked against whichever
+    /// in-memory collection holds it (album detail, queue).
+    pub(crate) fn is_starred(&self, id: &str, kind: firmium_backend::commands::subsonic::StarKind) -> bool {
+        use firmium_backend::commands::subsonic::StarKind;
+        match kind {
+            StarKind::Song => {
+                self.queue.iter().find(|s| s.id == id).map(|s| s.starred)
+                    .or_else(|| self.album_detail.as_ref()?.tracks.iter().find(|s| s.id == id).map(|s| s.starred))
+                    .unwrap_or(false)
+            }
+            StarKind::Album => self.album_detail.as_ref().is_some_and(|at| at.starred),
+            StarKind::Artist => false, // artist starring has no local UI state to flip (list-only in Favorites screen).
+        }
+    }
+
+    /// Flips the starred flag on every in-memory copy of this id (queue, album detail).
+    pub(crate) fn set_starred_locally(&mut self, id: &str, kind: firmium_backend::commands::subsonic::StarKind, starred: bool) {
+        use firmium_backend::commands::subsonic::StarKind;
+        match kind {
+            StarKind::Song => {
+                for s in self.queue.iter_mut() {
+                    if s.id == id { s.starred = starred; }
+                }
+                if let Some(at) = self.album_detail.as_mut() {
+                    for s in at.tracks.iter_mut() {
+                        if s.id == id { s.starred = starred; }
+                    }
+                }
+            }
+            StarKind::Album => {
+                if let Some(at) = self.album_detail.as_mut() {
+                    at.starred = starred;
+                }
+            }
+            StarKind::Artist => {}
+        }
+    }
+
     pub(crate) fn cover_image(&self, cover_id: Option<&str>, size: f32) -> Element<'_, Message> {
         let t = self.tokens;
         let radius = if size >= 80.0 { 14.0_f32 } else if size >= 40.0 { 10.0 } else { 6.0 };

--- a/desktop/src/app/message.rs
+++ b/desktop/src/app/message.rs
@@ -1,6 +1,6 @@
 use firmium_backend::commands::lyrics::LyricsResult;
-use firmium_backend::commands::mappers::{Album, Artist, SimilarMatch, Song};
-use firmium_backend::commands::subsonic::{AlbumTracks, ArtistDetails, ArtistInfo, Genre, PlaylistTracks, RemotePlayQueue, SearchResult};
+use firmium_backend::commands::mappers::{Album, Artist, SimilarMatch, Song, Starred};
+use firmium_backend::commands::subsonic::{AlbumTracks, ArtistDetails, ArtistInfo, Genre, PlaylistTracks, RemotePlayQueue, SearchResult, StarKind};
 use firmium_backend::config::SavedAccount;
 use firmium_backend::errors::UserError;
 use firmium_backend::events::BackendEvent;
@@ -56,6 +56,9 @@ pub enum Message {
     ShuffleAlbum,
     PlaySong(Song),
     SetRating(String, u32),
+    ToggleStar(String, StarKind),
+    StarToggled(String, StarKind, Result<bool, UserError>),
+    FavoritesLoaded(Result<Starred, UserError>),
     DownloadTrack(Song),
     DownloadDone(Result<(), String>),
 

--- a/desktop/src/app/mod.rs
+++ b/desktop/src/app/mod.rs
@@ -70,6 +70,7 @@ pub struct App {
     home_recent_artists_cache: Vec<(String, String, Option<String>)>,
     album_detail: Option<AlbumTracks>,
     album_detail_id: Option<String>,
+    favorites: Option<firmium_backend::commands::mappers::Starred>,
     album_tracks_scroll: f32,
     artists: Vec<Artist>,
     artists_scroll: f32,
@@ -296,6 +297,7 @@ impl App {
             home_recent_artists_cache: Vec::new(),
             album_detail: None,
             album_detail_id: None,
+            favorites: None,
             album_tracks_scroll: 0.0,
             artists: Vec::new(),
             artists_scroll: 0.0,
@@ -725,6 +727,7 @@ impl App {
 
         let nav = column![
             self.nav_button(icons::HOME, "Home", View::Home),
+            self.nav_button(icons::HEART_OUTLINE, "Favorites", View::Favorites),
             self.nav_button(icons::DISC, "Albums", View::Albums),
             self.nav_button(icons::USER, "Artists", View::Artists),
             self.nav_button(icons::LIST, "Playlists", View::Playlists),
@@ -765,6 +768,7 @@ impl App {
 
         let fixed_nav = column![
             self.nav_button(icons::HOME, "Home", View::Home),
+            self.nav_button(icons::HEART_OUTLINE, "Favorites", View::Favorites),
             self.nav_button(icons::SEARCH, "Search", View::Search),
             self.nav_button(icons::DISC, "Albums", View::Albums),
             self.nav_button(icons::USER, "Artists", View::Artists),

--- a/desktop/src/app/styles.rs
+++ b/desktop/src/app/styles.rs
@@ -35,6 +35,27 @@ pub(crate) fn primary_button(t: Tokens, spotify: bool) -> impl Fn(&Theme, button
     }
 }
 
+/// Outlined secondary action button (Shuffle/Download on album detail): a
+/// bordered `surface2` pill in spotify theme, the existing flat 4px-radius
+/// look otherwise — mirrors Android's `AlbumDetailScreen`'s Shuffle button,
+/// which already borders + pills in spotify mode.
+pub(crate) fn outline_pill_button(t: Tokens, spotify: bool) -> impl Fn(&Theme, button::Status) -> button::Style {
+    let radius = if spotify { 500.0 } else { 4.0 };
+    move |_theme, status| {
+        let hovered = matches!(status, button::Status::Hovered | button::Status::Pressed);
+        button::Style {
+            background: Some(Background::Color(if hovered { t.surface } else { t.surface2 })),
+            text_color: t.text,
+            border: Border {
+                radius: radius.into(),
+                width: if spotify { 1.0 } else { 0.0 },
+                color: t.border,
+            },
+            ..button::Style::default()
+        }
+    }
+}
+
 pub(crate) fn section_label(label: &'static str, t: Tokens) -> Element<'static, Message> {
     text(label).size(11).style(tstyle(t.muted)).into()
 }

--- a/desktop/src/app/types.rs
+++ b/desktop/src/app/types.rs
@@ -3,6 +3,7 @@ use firmium_backend::errors::UserError;
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum View {
     Home,
+    Favorites,
     Albums,
     AlbumDetail(String),
     Artists,
@@ -32,6 +33,7 @@ impl View {
     pub(crate) fn title(&self) -> &'static str {
         match self {
             View::Home => "Home",
+            View::Favorites => "Favorites",
             View::Albums => "Albums",
             View::AlbumDetail(_) => "Album",
             View::Artists => "Artists",

--- a/desktop/src/app/update/library.rs
+++ b/desktop/src/app/update/library.rs
@@ -184,6 +184,39 @@ impl App {
                     |_| Message::DownloadDone(Ok(())),
                 )
             }
+            Message::ToggleStar(id, kind) => {
+                // Optimistic: figure out current starred state from whichever
+                // in-memory collection holds this id, flip it locally, then
+                // fire the network call. On failure, StarToggled reverts it.
+                let currently_starred = self.is_starred(&id, kind);
+                self.set_starred_locally(&id, kind, !currently_starred);
+                let state = self.backend.app_state.clone();
+                let id2 = id.clone();
+                Task::perform(
+                    async move {
+                        let result = if currently_starred {
+                            firmium_backend::commands::subsonic::unstar_item(state, id2, kind).await
+                        } else {
+                            firmium_backend::commands::subsonic::star_item(state, id2, kind).await
+                        };
+                        result.map(|_| !currently_starred)
+                    },
+                    move |r| Message::StarToggled(id.clone(), kind, r),
+                )
+            }
+            Message::StarToggled(id, kind, result) => {
+                if let Err(_e) = result {
+                    // Revert the optimistic flip — re-read what it should have stayed as.
+                    let reverted = !self.is_starred(&id, kind);
+                    self.set_starred_locally(&id, kind, reverted);
+                }
+                Task::none()
+            }
+            Message::FavoritesLoaded(Ok(starred)) => {
+                self.favorites = Some(starred);
+                Task::none()
+            }
+            Message::FavoritesLoaded(Err(_e)) => Task::none(),
             Message::DownloadTrack(song) => Task::perform(
                 firmium_backend::commands::downloads::download_track(
                     self.backend.app_state.clone(),

--- a/desktop/src/app/update/mod.rs
+++ b/desktop/src/app/update/mod.rs
@@ -46,6 +46,9 @@ impl App {
             | Message::ShuffleAlbum
             | Message::PlaySong(..)
             | Message::SetRating(..)
+            | Message::ToggleStar(..)
+            | Message::StarToggled(..)
+            | Message::FavoritesLoaded(..)
             | Message::DownloadTrack(..)
             | Message::DownloadDone(..)
             | Message::GenresLoaded(..)

--- a/desktop/src/app/update/nav.rs
+++ b/desktop/src/app/update/nav.rs
@@ -27,6 +27,7 @@ impl App {
                                     album_name: r.album_name,
                                     album_artist: r.album_artist,
                                     cover_art_id: r.cover_art_id,
+                                    starred: false,
                                 })
                                 .map_err(|_| UserError::NotFound);
                             Task::done(Message::AlbumTracksLoaded(result))
@@ -57,6 +58,9 @@ impl App {
                                 Task::perform(firmium_backend::commands::subsonic::get_similar_artists(state, id, None), Message::SimilarArtistsLoaded),
                             ])
                         }
+                    }
+                    View::Favorites if self.favorites.is_none() => {
+                        Task::perform(firmium_backend::commands::subsonic::get_starred(state), Message::FavoritesLoaded)
                     }
                     View::PlaylistDetail(id) if self.playlist_detail_id.as_deref() != Some(id.as_str()) => {
                         self.playlist_detail = None;

--- a/desktop/src/app/view/albums.rs
+++ b/desktop/src/app/view/albums.rs
@@ -117,15 +117,7 @@ impl App {
         )
         .padding(8)
         .on_press(Message::ShuffleAlbum)
-        .style(move |_t, status| {
-            let h = matches!(status, button::Status::Hovered | button::Status::Pressed);
-            button::Style {
-                background: Some(Background::Color(if h { t.surface } else { t.surface2 })),
-                text_color: t.text,
-                border: Border { radius: 4.0.into(), ..Border::default() },
-                ..button::Style::default()
-            }
-        });
+        .style(outline_pill_button(t, spotify));
 
         let album_download_btn = button(
             row![
@@ -137,24 +129,27 @@ impl App {
         )
         .padding(8)
         .on_press(Message::DownloadAlbum)
-        .style(move |_t, status| {
-            let h = matches!(status, button::Status::Hovered | button::Status::Pressed);
-            button::Style {
-                background: Some(Background::Color(if h { t.surface } else { t.surface2 })),
-                text_color: t.text,
-                border: Border { radius: 4.0.into(), ..Border::default() },
-                ..button::Style::default()
-            }
-        });
+        .style(outline_pill_button(t, spotify));
 
         let header = row![
-            self.cover_image(at.cover_art_id.as_deref(), 80.0),
+            self.cover_image(at.cover_art_id.as_deref(), if spotify { 130.0 } else { 80.0 }),
             column![
                 text(at.album_name.clone()).size(18).style(tstyle(t.text)).font(iced::Font {
                     weight: iced::font::Weight::Bold,
                     ..iced::Font::MONOSPACE
                 }),
-                text(at.album_artist.clone()).size(13).style(tstyle(t.muted)),
+                row![
+                    text(at.album_artist.clone()).size(13).style(tstyle(t.muted)),
+                    icon_button(
+                        if at.starred { icons::HEART_FILLED } else { icons::HEART_OUTLINE },
+                        14.0,
+                        if at.starred { t.accent } else { t.muted },
+                        t, spotify,
+                        Message::ToggleStar(self.album_detail_id.clone().unwrap_or_default(), firmium_backend::commands::subsonic::StarKind::Album),
+                    ),
+                ]
+                .spacing(8)
+                .align_y(Alignment::Center),
                 text(format!("{} tracks", at.tracks.len())).size(11).style(tstyle(t.muted)),
                 row![play_btn, shuffle_btn, album_download_btn].spacing(8),
             ]
@@ -225,6 +220,13 @@ impl App {
             play_area,
             self.star_rating(song),
             self.avg_rating_badge(song),
+            icon_button(
+                if song.starred { icons::HEART_FILLED } else { icons::HEART_OUTLINE },
+                14.0,
+                if song.starred { t.accent } else { t.muted },
+                t, spotify,
+                Message::ToggleStar(song.id.clone(), firmium_backend::commands::subsonic::StarKind::Song),
+            ),
             icon_button(icons::PLUS, 14.0, t.muted, t, spotify, Message::OpenAddToPlaylist(song.clone())),
             icon_button(icons::DOWNLOAD, 14.0, t.muted, t, spotify, Message::DownloadTrack(song.clone())),
             text(fmt_time(song.duration)).size(11).style(tstyle(t.muted)).width(Length::Fixed(44.0)),

--- a/desktop/src/app/view/favorites.rs
+++ b/desktop/src/app/view/favorites.rs
@@ -1,0 +1,65 @@
+use iced::widget::{button, column, row, scrollable, text};
+use iced::{Element, Length};
+
+use super::super::message::Message;
+use super::super::styles::*;
+use super::super::types::View;
+use super::super::App;
+
+impl App {
+    pub(crate) fn favorites_view(&self) -> Element<'_, Message> {
+        let t = self.tokens;
+        let spotify = self.ui_theme_id == "spotify";
+        let header = page_header("Favorites", t, spotify);
+
+        let Some(starred) = &self.favorites else {
+            return column![header, text("Loading…").size(13).style(tstyle(t.muted))].spacing(16).into();
+        };
+
+        let mut sections = column![header].spacing(28);
+
+        if !starred.albums.is_empty() {
+            let mut cards = row![].spacing(if spotify { 16 } else { 12 });
+            for a in starred.albums.iter().take(20) {
+                cards = cards.push(self.album_card(a));
+            }
+            sections = sections.push(
+                column![
+                    shelf_label("ALBUMS", t, spotify),
+                    scrollable(cards).direction(scrollable::Direction::Horizontal(Default::default())),
+                ]
+                .spacing(12),
+            );
+        }
+
+        if !starred.songs.is_empty() {
+            let mut list = column![];
+            for (i, song) in starred.songs.iter().enumerate() {
+                list = list.push(self.track_row(i, song, Message::PlaySong(song.clone())));
+            }
+            sections = sections.push(column![shelf_label("SONGS", t, spotify), list].spacing(12));
+        }
+
+        if !starred.artists.is_empty() {
+            let mut list = column![];
+            for artist in &starred.artists {
+                list = list.push(
+                    button(text(artist.name.clone()).size(14).style(tstyle(t.text)))
+                        .on_press(Message::Navigate(View::ArtistDetail(artist.id.clone())))
+                        .style(list_row_style(t, spotify)),
+                );
+            }
+            sections = sections.push(column![shelf_label("ARTISTS", t, spotify), list].spacing(12));
+        }
+
+        if starred.albums.is_empty() && starred.songs.is_empty() && starred.artists.is_empty() {
+            sections = sections.push(
+                text("No favorites yet — tap the heart on any song, album, or artist.")
+                    .size(13)
+                    .style(tstyle(t.muted)),
+            );
+        }
+
+        scrollable(sections).width(Length::Fill).height(Length::Fill).style(thin_scroll_style(t)).into()
+    }
+}

--- a/desktop/src/app/view/home.rs
+++ b/desktop/src/app/view/home.rs
@@ -2,6 +2,7 @@ use iced::widget::{button, column, responsive, row, scrollable, text};
 use iced::{Alignment, Background, Border, Element, Length};
 
 use firmium_backend::commands::mappers::Album;
+use crate::icons;
 
 use super::super::message::Message;
 use super::super::styles::*;
@@ -48,39 +49,71 @@ impl App {
     /// shown above the shelves — Spotify's most recognizable home pattern.
     pub(crate) fn home_quick_access(&self) -> Element<'_, Message> {
         let t = self.tokens;
-        if self.home_recent_plays.is_empty() {
-            return column![].into();
-        }
-        let items: Vec<_> = self.home_recent_plays.iter().take(6).collect();
-        let mut grid = column![].spacing(8);
-        for chunk in items.chunks(3) {
-            let mut line = row![].spacing(8);
-            for play in chunk {
-                let cover = self.cover_image(play.cover_art_id.as_deref(), 56.0);
-                let title = text(play.track_title.clone()).size(13).style(tstyle(t.text)).font(iced::Font {
+        let favorites_tile = button(
+            row![
+                icons::icon(icons::HEART_OUTLINE, 24.0, t.accent),
+                text("Favorites").size(13).style(tstyle(t.text)).font(iced::Font {
                     weight: iced::font::Weight::Bold,
                     ..iced::Font::with_name("Inter")
-                });
-                let mut card = button(row![cover, title].spacing(12).align_y(Alignment::Center))
-                    .width(Length::Fill)
-                    .padding(0)
-                    .style(move |_th, status| {
-                        let h = matches!(status, button::Status::Hovered | button::Status::Pressed);
-                        button::Style {
-                            background: Some(Background::Color(if h { t.surface2 } else { t.surface })),
-                            text_color: t.text,
-                            border: Border { radius: 6.0.into(), ..Border::default() },
-                            ..button::Style::default()
-                        }
-                    });
-                if let Some(aid) = play.album_id.clone() {
-                    card = card.on_press(Message::Navigate(View::AlbumDetail(aid)));
-                }
-                line = line.push(card);
+                }),
+            ]
+            .spacing(12)
+            .align_y(Alignment::Center),
+        )
+        .width(Length::Fill)
+        .padding(0)
+        .on_press(Message::Navigate(View::Favorites))
+        .style(move |_th, status| {
+            let h = matches!(status, button::Status::Hovered | button::Status::Pressed);
+            button::Style {
+                background: Some(Background::Color(if h { t.surface2 } else { t.surface })),
+                text_color: t.text,
+                border: Border { radius: 6.0.into(), ..Border::default() },
+                ..button::Style::default()
+            }
+        });
+
+        let items: Vec<_> = self.home_recent_plays.iter().take(5).collect();
+        let mut grid = column![].spacing(8);
+        let mut first_row = row![].spacing(8).push(favorites_tile);
+        let mut remaining = items.iter();
+        if let Some(play) = remaining.next() {
+            first_row = first_row.push(self.home_quick_access_card(play));
+        }
+        grid = grid.push(first_row);
+        for chunk in remaining.collect::<Vec<_>>().chunks(3) {
+            let mut line = row![].spacing(8);
+            for play in chunk {
+                line = line.push(self.home_quick_access_card(play));
             }
             grid = grid.push(line);
         }
         grid.into()
+    }
+
+    fn home_quick_access_card<'a>(&'a self, play: &'a firmium_backend::db::RecentPlay) -> Element<'a, Message> {
+        let t = self.tokens;
+        let cover = self.cover_image(play.cover_art_id.as_deref(), 56.0);
+        let title = text(play.track_title.clone()).size(13).style(tstyle(t.text)).font(iced::Font {
+            weight: iced::font::Weight::Bold,
+            ..iced::Font::with_name("Inter")
+        });
+        let mut card = button(row![cover, title].spacing(12).align_y(Alignment::Center))
+            .width(Length::Fill)
+            .padding(0)
+            .style(move |_th, status| {
+                let h = matches!(status, button::Status::Hovered | button::Status::Pressed);
+                button::Style {
+                    background: Some(Background::Color(if h { t.surface2 } else { t.surface })),
+                    text_color: t.text,
+                    border: Border { radius: 6.0.into(), ..Border::default() },
+                    ..button::Style::default()
+                }
+            });
+        if let Some(aid) = play.album_id.clone() {
+            card = card.on_press(Message::Navigate(View::AlbumDetail(aid)));
+        }
+        card.into()
     }
 
     pub(crate) fn home_recent_songs_view(&self) -> Element<'_, Message> {

--- a/desktop/src/app/view/mod.rs
+++ b/desktop/src/app/view/mod.rs
@@ -1,5 +1,6 @@
 mod albums;
 mod artists;
+mod favorites;
 mod genres;
 mod home;
 mod mix;
@@ -23,6 +24,7 @@ impl App {
     pub(crate) fn content_view(&self) -> Element<'_, Message> {
         match &self.view {
             View::Home => self.home_view(),
+            View::Favorites => self.favorites_view(),
             View::Albums => self.album_list_view(),
             View::AlbumDetail(_) => self.album_detail_view(),
             View::Artists => self.artists_view(),

--- a/desktop/src/app/view/player_bar.rs
+++ b/desktop/src/app/view/player_bar.rs
@@ -113,7 +113,7 @@ impl App {
         let cover = self.cover_image(song.and_then(|s| s.cover_art_id.as_deref()), 56.0);
         let title_text = song.map(|s| s.title.clone()).unwrap_or_else(|| "No track selected".to_string());
         let artist_text = song.map(|s| s.artist.clone()).unwrap_or_default();
-        let liked = song.is_some_and(|s| s.user_rating.unwrap_or(0) > 0);
+        let liked = song.is_some_and(|s| s.starred);
         let heart = if let Some(s) = song {
             let id = s.id.clone();
             icon_button(
@@ -122,7 +122,7 @@ impl App {
                 if liked { t.accent } else { t.muted },
                 t,
                 true,
-                Message::SetRating(id, if liked { 0 } else { 5 }),
+                Message::ToggleStar(id, firmium_backend::commands::subsonic::StarKind::Song),
             )
         } else {
             icons::icon(icons::HEART_OUTLINE, 15.0, t.muted)

--- a/termium/src/app.rs
+++ b/termium/src/app.rs
@@ -366,6 +366,7 @@ mod tests {
             genres: None,
             year: None,
             is_compilation: false,
+            starred: false,
         }
     }
 }


### PR DESCRIPTION
## Summary
- Favorites screen/view on desktop (`desktop/src/app/view/favorites.rs`) and Android (`FavoritesScreen.kt`, `FavoriteButton.kt`)
- Backend/API support for favorite tracking via local library and Subsonic
- Spotify-layout home/player bar polish across desktop, Android, Termium

## Test plan
- [x] Workspace Rust tests: 97 pass
- [x] `cargo clippy`: clean
- [x] Android: `BUILD SUCCESSFUL`