### PR TITLE
Add opus codec support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           operating_system: freebsd
           version: '14.2'
           run: |
-            sudo pkg install -y rust alsa-lib dbus libxkbcommon pkgconf
+            sudo pkg install -y rust alsa-lib dbus libxkbcommon pkgconf cmake
             cargo test
             cargo clippy --all-targets -- -D warnings
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,7 +317,7 @@ jobs:
           operating_system: freebsd
           version: '14.2'
           run: |
-            sudo pkg install -y rust alsa-lib dbus libxkbcommon pkgconf
+            sudo pkg install -y rust alsa-lib dbus libxkbcommon pkgconf cmake
             cargo build --release
 
             mkdir -p stage/usr/bin stage/usr/share/applications \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,10 +6,11 @@ Thanks for your interest in contributing! Firmium is an OpenSubsonic music strea
 
 ### Prerequisites
 - Rust 1.80+ (install via [rustup](https://rustup.rs/))
-- On Linux: ALSA (`libasound2`), `libssl`, `libsecret`, `libxkbcommon`, plus a Vulkan/OpenGL driver (for iced's `wgpu` renderer). Package names vary by distro — see `README.md`.
-- On Windows: no extra system dependencies needed
-- On macOS: Xcode Command Line Tools (`xcode-select --install`) only
-- On FreeBSD: `alsa-lib`, `dbus`, `libxkbcommon` via `pkg install`, plus a Mesa/Vulkan driver
+- `cmake` and a C compiler (needed to build the bundled `libopus` for Opus decoding)
+- On Linux: ALSA (`libasound2`), `libssl`, `libsecret`, `libxkbcommon`, plus a Vulkan/OpenGL driver (for iced's `wgpu` renderer), plus `cmake`. Package names vary by distro — see `README.md`.
+- On Windows: install [CMake](https://cmake.org/download/) and the "Desktop development with C++" workload (Visual Studio Build Tools)
+- On macOS: Xcode Command Line Tools (`xcode-select --install`) for the C compiler, plus `cmake` (`brew install cmake`) — Xcode CLT doesn't include `cmake` itself
+- On FreeBSD: `alsa-lib`, `dbus`, `libxkbcommon`, `cmake` via `pkg install`, plus a Mesa/Vulkan driver
 
 ### Set Up Your Environment
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1451,7 +1451,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "firmium"
-version = "8.0.1"
+version = "8.1.0"
 dependencies = [
  "bytemuck",
  "dirs",
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "firmium-backend"
-version = "8.0.1"
+version = "8.1.0"
 dependencies = [
  "bytes",
  "cpal",
@@ -1486,6 +1486,7 @@ dependencies = [
  "serde",
  "serde_json",
  "symphonia",
+ "symphonia-adapter-libopus",
  "tokio",
  "toml",
  "uuid",
@@ -3777,6 +3778,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "opusic-sys"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6363e8eba20c5db07002d1d5f8aef11a1801e3ab11edf4c3333f9ad37c7ebf8d"
+dependencies = [
+ "cmake",
+]
+
+[[package]]
 name = "orbclient"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5295,6 +5305,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "symphonia-adapter-libopus"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bfc8e95f95c23ed1b5328eb66920ad28d9968c797f9c7aa755d4b45a5f47a41"
+dependencies = [
+ "log",
+ "opusic-sys",
+ "symphonia-core",
+]
+
+[[package]]
 name = "symphonia-bundle-flac"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5507,7 +5528,7 @@ dependencies = [
 
 [[package]]
 name = "termium"
-version = "8.0.1"
+version = "8.1.0"
 dependencies = [
  "crossterm",
  "firmium-backend",

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -9,7 +9,7 @@ license=('GPL-3.0-only')
 # cpal->alsa, rfd->gtk3, keyring->libsecret, winit->wayland/libxkbcommon,
 # wgpu->vulkan loader, iced text shaping->fontconfig.
 depends=('alsa-lib' 'gtk3' 'libsecret' 'libxkbcommon' 'wayland' 'vulkan-icd-loader' 'fontconfig')
-makedepends=('cargo')
+makedepends=('cargo' 'cmake')
 provides=('firmium-desktop')
 conflicts=('firmium-desktop-git')
 options=('!strip')

--- a/README.md
+++ b/README.md
@@ -186,10 +186,11 @@ sudo dpkg -i ./firmium_*.deb
 ### Prerequisites
 
 - Rust 1.80 or later (`rustup default stable`)
-- On Linux, system dependencies for your distribution (see [System Dependencies (Linux)](#system-dependencies-linux) above) — ALSA, libsecret, libxkbcommon, and a Vulkan/OpenGL driver
-- On Windows, no extra system dependencies needed — rustls handles TLS, Windows Credential Manager is built in
-- On macOS, Xcode Command Line Tools (`xcode-select --install`) — no other system libraries needed
-- On FreeBSD, system dependencies via `pkg` (see [System Dependencies (FreeBSD)](#system-dependencies) above) — `alsa-lib`, `dbus`, `libxkbcommon`, and a Mesa/Vulkan driver
+- `cmake` and a C compiler, needed to build the bundled `libopus` (Opus decoding) — see per-platform notes below
+- On Linux, system dependencies for your distribution (see [System Dependencies (Linux)](#system-dependencies-linux) above) — ALSA, libsecret, libxkbcommon, and a Vulkan/OpenGL driver; `cmake` via your package manager (e.g. `apt install cmake` / `dnf install cmake` / `pacman -S cmake`)
+- On Windows, install [CMake](https://cmake.org/download/) and the "Desktop development with C++" workload (Visual Studio Build Tools) — rustls handles TLS, Windows Credential Manager is built in
+- On macOS, Xcode Command Line Tools (`xcode-select --install`) for the C compiler, plus `cmake` (`brew install cmake`, or the installer from [cmake.org](https://cmake.org/download/)) — Xcode CLT doesn't include `cmake` itself
+- On FreeBSD, system dependencies via `pkg` (see [System Dependencies (FreeBSD)](#system-dependencies) above) — `alsa-lib`, `dbus`, `libxkbcommon`, `cmake`, and a Mesa/Vulkan driver
 
 ### Steps
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -12,6 +12,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 reqwest = { version = "0.13.4", features = ["json", "stream", "blocking", "rustls"] }
 symphonia = { version = "0.5.5", default-features = false, features = ["aac", "flac", "isomp4", "mp3", "ogg", "pcm", "vorbis", "wav"] }
+symphonia-adapter-libopus = "0.2"
 cpal = "0.17.3"
 tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "time", "sync", "net"] }
 uuid = { version = "1.23.3", features = ["v4", "serde"] }

--- a/backend/audio/decoder.rs
+++ b/backend/audio/decoder.rs
@@ -1,18 +1,31 @@
 //! Symphonia probe/decode wrapper. Opens a `MediaSource`, probes the
 //! container format, and decodes packets to interleaved f32 sample chunks.
 
+use std::sync::LazyLock;
 use std::time::Duration;
 use symphonia::core::audio::SampleBuffer;
-use symphonia::core::codecs::{Decoder, DecoderOptions};
+use symphonia::core::codecs::{CodecRegistry, Decoder, DecoderOptions};
 use symphonia::core::errors::Error as SymphoniaError;
 use symphonia::core::formats::{FormatReader, FormatOptions, SeekMode, SeekTo};
 use symphonia::core::io::{MediaSource, MediaSourceStream, MediaSourceStreamOptions};
 use symphonia::core::meta::MetadataOptions;
 use symphonia::core::probe::Hint;
 use symphonia::core::units::Time;
+use symphonia_adapter_libopus::OpusDecoder;
 
 /// Sample rate assumed when the container/codec doesn't report one up front.
 pub const DEFAULT_SAMPLE_RATE: u32 = 48_000;
+
+/// Symphonia only registers decoders enabled via its own feature flags.
+/// This doesn't include Opus (Symphonia has no native Opus decoder).
+/// This registers everything `symphonia::default` would, plus
+/// the `libopus`-backed adapter, so Ogg-Opus tracks can be decoded.
+static CODEC_REGISTRY: LazyLock<CodecRegistry> = LazyLock::new(|| {
+    let mut registry = CodecRegistry::new();
+    symphonia::default::register_enabled_codecs(&mut registry);
+    registry.register_all::<OpusDecoder>();
+    registry
+});
 
 pub struct DecoderHandle {
     format: Box<dyn FormatReader>,
@@ -37,7 +50,7 @@ impl DecoderHandle {
         let track_id = track.id;
         let codec_params = track.codec_params.clone();
 
-        let decoder = symphonia::default::get_codecs()
+        let decoder = CODEC_REGISTRY
             .make(&codec_params, &DecoderOptions::default())
             .map_err(|e| format!("Failed to create decoder: {e}"))?;
 

--- a/firmium.spec
+++ b/firmium.spec
@@ -11,6 +11,7 @@ Source0:        %{url}/archive/v%{version}.tar.gz
 BuildRequires:  cargo
 BuildRequires:  rust
 BuildRequires:  gcc
+BuildRequires:  cmake
 BuildRequires:  alsa-lib-devel
 BuildRequires:  gtk3-devel
 BuildRequires:  libsecret-devel

--- a/packaging/firmium.spec
+++ b/packaging/firmium.spec
@@ -20,6 +20,7 @@ Source1:        firmium-VERSION_PLACEHOLDER-vendor.tar.xz
 BuildRequires:  cargo
 BuildRequires:  rust
 BuildRequires:  gcc
+BuildRequires:  cmake
 BuildRequires:  alsa-lib-devel
 BuildRequires:  gtk3-devel
 BuildRequires:  libsecret-devel


### PR DESCRIPTION
Firmium currently has no way to play audio with the opus codec, this is due to Symphonia having no native Opus decoder.

This branch adds a libopus wrapper for symphonia called symphonia-adapter-libopus. It's statically bundled and registers alongside the built in decoders. symphonia-adapter-libopus is constrained to 0.2.X (currently resolves to 0.2.9) to support the current 0.5.5 symphonia version, 0.3.0 introduced a 0.6 symphonia requirement.

Bundling libopus from source requires cmake + a C compiler at build time. All related docs and CI have been changed accordingly to add cmake.

It's been tested locally successfully through:
* cargo build --workspace
* cargo test --workspace
* cargo clippy --all-targets --all-features -- -D warnings
* cargo run -p firmium
* Manual .opus playback.

No crashes or errors were found locally.