### PR TITLE
Add mouse back/forward navigation to desktop app

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1451,7 +1451,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "firmium"
-version = "8.0.1"
+version = "8.1.0"
 dependencies = [
  "bytemuck",
  "dirs",
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "firmium-backend"
-version = "8.0.1"
+version = "8.1.0"
 dependencies = [
  "bytes",
  "cpal",
@@ -5507,7 +5507,7 @@ dependencies = [
 
 [[package]]
 name = "termium"
-version = "8.0.1"
+version = "8.1.0"
 dependencies = [
  "crossterm",
  "firmium-backend",

--- a/desktop/src/app/message.rs
+++ b/desktop/src/app/message.rs
@@ -17,6 +17,7 @@ use super::types::{Energy, HomeSection, Panel, RecapRange, SettingsCategory, Vie
 pub enum Message {
     Navigate(View),
     NavigateBack,
+    NavigateForward,
     Backend(BackendEvent),
     VisualizerTick,
     // Global Escape key press; dispatched to whichever overlay is currently open.

--- a/desktop/src/app/mod.rs
+++ b/desktop/src/app/mod.rs
@@ -57,6 +57,7 @@ pub struct App {
 
     view: View,
     nav_stack: Vec<View>,
+    forward_stack: Vec<View>,
 
     // ── Library data ──────────────────────────────────────────────────────────
     albums: Vec<Album>,
@@ -288,6 +289,7 @@ impl App {
             next_toast_id: 0,
             view: View::Home,
             nav_stack: Vec::new(),
+            forward_stack: Vec::new(),
             albums: Vec::new(),
             albums_scroll: 0.0,
             home_recent: Vec::new(),

--- a/desktop/src/app/subscription.rs
+++ b/desktop/src/app/subscription.rs
@@ -1,6 +1,6 @@
 use std::hash::{Hash, Hasher};
 
-use iced::keyboard;
+use iced::{event, keyboard, mouse, window};
 use iced::Subscription;
 
 use firmium_backend::events::EventBus;
@@ -15,6 +15,7 @@ impl App {
         Subscription::batch([
             bus,
             keyboard::listen().filter_map(key_message),
+            event::listen_with(mouse_message),
             if self.right_panel == Some(Panel::Visualizer) {
                 iced::time::every(std::time::Duration::from_millis(16)).map(|_| Message::VisualizerTick)
             } else {
@@ -43,6 +44,18 @@ fn key_message(event: keyboard::Event) -> Option<Message> {
         }
         keyboard::Event::KeyPressed { key: keyboard::Key::Named(keyboard::key::Named::Space), .. } => {
             Some(Message::TogglePlay)
+        }
+        _ => None,
+    }
+}
+
+fn mouse_message(event: iced::Event, status: event::Status, _window: window::Id) -> Option<Message> {
+    match (event, status) {
+        (iced::Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Back)), event::Status::Ignored) => {
+            Some(Message::NavigateBack)
+        }
+        (iced::Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Forward)), event::Status::Ignored) => {
+            Some(Message::NavigateForward)
         }
         _ => None,
     }

--- a/desktop/src/app/update/auth.rs
+++ b/desktop/src/app/update/auth.rs
@@ -123,6 +123,8 @@ impl App {
                 self.authed = false;
                 self.show_account_switcher = true;
                 self.search_results = None;
+                self.nav_stack.clear();
+                self.forward_stack.clear();
                 self.populate_offline_library();
                 self.save_config();
                 Task::batch([self.load_covers(), self.load_cover_ids(self.offline_home_cover_ids())])
@@ -217,5 +219,6 @@ impl App {
         self.genre_detail_name = None;
         self.view = View::Home;
         self.nav_stack.clear();
+        self.forward_stack.clear();
     }
 }

--- a/desktop/src/app/update/mod.rs
+++ b/desktop/src/app/update/mod.rs
@@ -197,6 +197,7 @@ impl App {
             | Message::PlayPodcastEpisode(..) => self.update_podcasts(message),
             Message::Navigate(..)
             | Message::NavigateBack
+            | Message::NavigateForward
             | Message::Backend(..)
             | Message::VisualizerTick
             | Message::ShowToast(..)

--- a/desktop/src/app/update/nav.rs
+++ b/desktop/src/app/update/nav.rs
@@ -12,137 +12,34 @@ impl App {
             Message::Navigate(view) => {
                 if view != self.view {
                     self.nav_stack.push(self.view.clone());
+                    self.forward_stack.clear();
                     self.view = view;
                 }
-                let state = self.backend.app_state.clone();
-                match self.view.clone() {
-                    View::AlbumDetail(id) if self.album_detail_id.as_deref() != Some(id.as_str()) => {
-                        self.album_detail = None;
-                        self.album_detail_id = Some(id.clone());
-                        self.album_tracks_scroll = 0.0;
-                        if id.starts_with("local:") {
-                            let result = firmium_backend::commands::local_library::get_local_album_tracks(&self.backend.app_state, id)
-                                .map(|r| firmium_backend::commands::subsonic::AlbumTracks {
-                                    tracks: r.tracks,
-                                    album_name: r.album_name,
-                                    album_artist: r.album_artist,
-                                    cover_art_id: r.cover_art_id,
-                                    starred: false,
-                                })
-                                .map_err(|_| UserError::NotFound);
-                            Task::done(Message::AlbumTracksLoaded(result))
-                        } else {
-                            Task::perform(firmium_backend::commands::subsonic::get_album_tracks(state, id), Message::AlbumTracksLoaded)
-                        }
-                    }
-                    View::ArtistDetail(id) if self.artist_detail_id.as_deref() != Some(id.as_str()) => {
-                        self.artist_detail = None;
-                        self.artist_info = None;
-                        self.similar_artists.clear();
-                        self.artist_detail_id = Some(id.clone());
-                        if id.starts_with("local:") {
-                            let result = firmium_backend::commands::local_library::get_local_artist_details(&self.backend.app_state, id)
-                                .map(|r| firmium_backend::commands::subsonic::ArtistDetails { name: r.name, albums: r.albums })
-                                .map_err(|_| UserError::NotFound);
-                            Task::done(Message::ArtistDetailLoaded(result))
-                        } else {
-                            let artist_name = self
-                                .artists
-                                .iter()
-                                .find(|a| a.id == *id)
-                                .map(|a| a.name.clone())
-                                .unwrap_or_default();
-                            Task::batch([
-                                Task::perform(firmium_backend::commands::subsonic::get_artist_details(state.clone(), id.clone()), Message::ArtistDetailLoaded),
-                                Task::perform(firmium_backend::commands::subsonic::get_artist_info(state.clone(), id.clone(), self.lastfm_key.clone(), artist_name), Message::ArtistInfoLoaded),
-                                Task::perform(firmium_backend::commands::subsonic::get_similar_artists(state, id, None), Message::SimilarArtistsLoaded),
-                            ])
-                        }
-                    }
-                    View::Favorites if self.favorites.is_none() => {
-                        Task::perform(firmium_backend::commands::subsonic::get_starred(state), Message::FavoritesLoaded)
-                    }
-                    View::PlaylistDetail(id) if self.playlist_detail_id.as_deref() != Some(id.as_str()) => {
-                        self.playlist_detail = None;
-                        self.playlist_detail_id = Some(id.clone());
-                        self.playlist_tracks_scroll = 0.0;
-                        self.renaming_playlist = None;
-                        if let Some(server_id) = id.strip_prefix("server-") {
-                            Task::perform(
-                                firmium_backend::commands::subsonic::get_playlist_tracks(state, server_id.to_string()),
-                                Message::PlaylistTracksLoaded,
-                            )
-                        } else {
-                            // Local playlist: build detail from memory, no fetch.
-                            self.refresh_local_detail(&id);
-                            Task::none()
-                        }
-                    }
-                    View::Artists if self.artists.is_empty() => {
-                        Task::perform(firmium_backend::commands::subsonic::get_artists(state), Message::ArtistsLoaded)
-                    }
-                    View::Playlists => {
-                        Task::perform(firmium_backend::commands::subsonic::get_playlists(state), Message::PlaylistsLoaded)
-                    }
-                    View::Recap => self.compute_recap(),
-                    View::GenreDetail(name) if self.genre_detail_name.as_deref() != Some(name.as_str()) => {
-                        self.genre_songs.clear();
-                        self.genre_detail_name = Some(name.clone());
-                        Task::perform(firmium_backend::commands::subsonic::get_songs_by_genre(state, name, None), Message::GenreSongsLoaded)
-                    }
-                    View::Settings => {
-                        self.load_history_summary();
-                        Task::none()
-                    }
-                    View::Podcasts => {
-                        if let Some(store) = self.backend.podcasts.clone() {
-                            Task::perform(
-                                async move { firmium_backend::podcasts::list_channels(store) },
-                                Message::PodcastChannelsLoaded,
-                            )
-                        } else {
-                            Task::none()
-                        }
-                    }
-                    View::PodcastDetail(id) => {
-                        if let Some(store) = self.backend.podcasts.clone() {
-                            Task::perform(
-                                async move { firmium_backend::podcasts::list_episodes(store, id) },
-                                Message::PodcastEpisodesLoaded,
-                            )
-                        } else {
-                            Task::none()
-                        }
-                    }
-                    View::Home => {
-                        if let Some(history) = &self.backend.history {
-                            self.home_recent_plays = history.recent_plays(15).unwrap_or_default();
-                            self.recompute_home_recent_artists();
-                        }
-                        let play_cover_ids: Vec<String> = self.home_recent_plays.iter()
-                            .filter_map(|p| p.cover_art_id.clone())
-                            .collect();
-                        let cover_task = self.load_cover_ids(play_cover_ids);
-                        if self.home_newest.is_empty() {
-                            Task::batch([
-                                Task::perform(firmium_backend::commands::subsonic::get_recent_albums(state.clone(), 12), |r| Message::HomeAlbumsLoaded(HomeSection::Recent, r)),
-                                Task::perform(firmium_backend::commands::subsonic::get_newest_albums(state.clone(), 12), |r| Message::HomeAlbumsLoaded(HomeSection::Newest, r)),
-                                Task::perform(firmium_backend::commands::subsonic::get_random_albums(state.clone(), 12), |r| Message::HomeAlbumsLoaded(HomeSection::Random, r)),
-                                Task::perform(firmium_backend::commands::subsonic::get_genres_list(state), Message::GenresLoaded),
-                                cover_task,
-                            ])
-                        } else {
-                            cover_task
-                        }
-                    }
-                    _ => Task::none(),
-                }
+                self.load_view_data()
             }
             Message::NavigateBack => {
-                if let Some(view) = self.nav_stack.pop() {
-                    self.view = view;
+                if self.any_overlay_open() {
+                    return self.update(Message::EscapePressed);
                 }
-                Task::none()
+                if let Some(view) = self.nav_stack.pop() {
+                    self.forward_stack.push(self.view.clone());
+                    self.view = view;
+                    self.load_view_data()
+                } else {
+                    Task::none()
+                }
+            }
+            Message::NavigateForward => {
+                if self.any_overlay_open() {
+                    return self.update(Message::EscapePressed);
+                }
+                if let Some(view) = self.forward_stack.pop() {
+                    self.nav_stack.push(self.view.clone());
+                    self.view = view;
+                    self.load_view_data()
+                } else {
+                    Task::none()
+                }
             }
             Message::Backend(event) => {
                 self.handle_backend(event);
@@ -179,6 +76,140 @@ impl App {
 
             // ── Onboarding ────────────────────────────────────────────────────
             _ => unreachable!(),
+        }
+    }
+
+    // Whether a modal overlay is currently on top, per the stacking order in `shell()`.
+    fn any_overlay_open(&self) -> bool {
+        self.show_account_switcher
+            || self.add_to_playlist_song.is_some()
+            || self.show_create_playlist
+            || self.podcast_add_modal_open
+    }
+
+    fn load_view_data(&mut self) -> Task<Message> {
+        let state = self.backend.app_state.clone();
+        match self.view.clone() {
+            View::AlbumDetail(id) if self.album_detail_id.as_deref() != Some(id.as_str()) => {
+                self.album_detail = None;
+                self.album_detail_id = Some(id.clone());
+                self.album_tracks_scroll = 0.0;
+                if id.starts_with("local:") {
+                    let result = firmium_backend::commands::local_library::get_local_album_tracks(&self.backend.app_state, id)
+                        .map(|r| firmium_backend::commands::subsonic::AlbumTracks {
+                            tracks: r.tracks,
+                            album_name: r.album_name,
+                            album_artist: r.album_artist,
+                            cover_art_id: r.cover_art_id,
+                            starred: false,
+                        })
+                        .map_err(|_| UserError::NotFound);
+                    Task::done(Message::AlbumTracksLoaded(result))
+                } else {
+                    Task::perform(firmium_backend::commands::subsonic::get_album_tracks(state, id), Message::AlbumTracksLoaded)
+                }
+            }
+            View::ArtistDetail(id) if self.artist_detail_id.as_deref() != Some(id.as_str()) => {
+                self.artist_detail = None;
+                self.artist_info = None;
+                self.similar_artists.clear();
+                self.artist_detail_id = Some(id.clone());
+                if id.starts_with("local:") {
+                    let result = firmium_backend::commands::local_library::get_local_artist_details(&self.backend.app_state, id)
+                        .map(|r| firmium_backend::commands::subsonic::ArtistDetails { name: r.name, albums: r.albums })
+                        .map_err(|_| UserError::NotFound);
+                    Task::done(Message::ArtistDetailLoaded(result))
+                } else {
+                    let artist_name = self
+                        .artists
+                        .iter()
+                        .find(|a| a.id == *id)
+                        .map(|a| a.name.clone())
+                        .unwrap_or_default();
+                    Task::batch([
+                        Task::perform(firmium_backend::commands::subsonic::get_artist_details(state.clone(), id.clone()), Message::ArtistDetailLoaded),
+                        Task::perform(firmium_backend::commands::subsonic::get_artist_info(state.clone(), id.clone(), self.lastfm_key.clone(), artist_name), Message::ArtistInfoLoaded),
+                        Task::perform(firmium_backend::commands::subsonic::get_similar_artists(state, id, None), Message::SimilarArtistsLoaded),
+                    ])
+                }
+            }
+            View::Favorites if self.favorites.is_none() => {
+                Task::perform(firmium_backend::commands::subsonic::get_starred(state), Message::FavoritesLoaded)
+            }
+            View::PlaylistDetail(id) if self.playlist_detail_id.as_deref() != Some(id.as_str()) => {
+                self.playlist_detail = None;
+                self.playlist_detail_id = Some(id.clone());
+                self.playlist_tracks_scroll = 0.0;
+                self.renaming_playlist = None;
+                if let Some(server_id) = id.strip_prefix("server-") {
+                    Task::perform(
+                        firmium_backend::commands::subsonic::get_playlist_tracks(state, server_id.to_string()),
+                        Message::PlaylistTracksLoaded,
+                    )
+                } else {
+                    // Local playlist: build detail from memory, no fetch.
+                    self.refresh_local_detail(&id);
+                    Task::none()
+                }
+            }
+            View::Artists if self.artists.is_empty() => {
+                Task::perform(firmium_backend::commands::subsonic::get_artists(state), Message::ArtistsLoaded)
+            }
+            View::Playlists => {
+                Task::perform(firmium_backend::commands::subsonic::get_playlists(state), Message::PlaylistsLoaded)
+            }
+            View::Recap => self.compute_recap(),
+            View::GenreDetail(name) if self.genre_detail_name.as_deref() != Some(name.as_str()) => {
+                self.genre_songs.clear();
+                self.genre_detail_name = Some(name.clone());
+                Task::perform(firmium_backend::commands::subsonic::get_songs_by_genre(state, name, None), Message::GenreSongsLoaded)
+            }
+            View::Settings => {
+                self.load_history_summary();
+                Task::none()
+            }
+            View::Podcasts => {
+                if let Some(store) = self.backend.podcasts.clone() {
+                    Task::perform(
+                        async move { firmium_backend::podcasts::list_channels(store) },
+                        Message::PodcastChannelsLoaded,
+                    )
+                } else {
+                    Task::none()
+                }
+            }
+            View::PodcastDetail(id) => {
+                if let Some(store) = self.backend.podcasts.clone() {
+                    Task::perform(
+                        async move { firmium_backend::podcasts::list_episodes(store, id) },
+                        Message::PodcastEpisodesLoaded,
+                    )
+                } else {
+                    Task::none()
+                }
+            }
+            View::Home => {
+                if let Some(history) = &self.backend.history {
+                    self.home_recent_plays = history.recent_plays(15).unwrap_or_default();
+                    self.recompute_home_recent_artists();
+                }
+                let play_cover_ids: Vec<String> = self.home_recent_plays.iter()
+                    .filter_map(|p| p.cover_art_id.clone())
+                    .collect();
+                let cover_task = self.load_cover_ids(play_cover_ids);
+                if self.home_newest.is_empty() {
+                    Task::batch([
+                        Task::perform(firmium_backend::commands::subsonic::get_recent_albums(state.clone(), 12), |r| Message::HomeAlbumsLoaded(HomeSection::Recent, r)),
+                        Task::perform(firmium_backend::commands::subsonic::get_newest_albums(state.clone(), 12), |r| Message::HomeAlbumsLoaded(HomeSection::Newest, r)),
+                        Task::perform(firmium_backend::commands::subsonic::get_random_albums(state.clone(), 12), |r| Message::HomeAlbumsLoaded(HomeSection::Random, r)),
+                        Task::perform(firmium_backend::commands::subsonic::get_genres_list(state), Message::GenresLoaded),
+                        cover_task,
+                    ])
+                } else {
+                    cover_task
+                }
+            }
+            _ => Task::none(),
         }
     }
 }

--- a/desktop/src/app/update/playlists.rs
+++ b/desktop/src/app/update/playlists.rs
@@ -251,6 +251,8 @@ impl App {
                     self.playlist_detail = None;
                     self.playlist_detail_id = None;
                 }
+                self.nav_stack.retain(|v| *v != View::PlaylistDetail(local_id.clone()));
+                self.forward_stack.retain(|v| *v != View::PlaylistDetail(local_id.clone()));
                 match server_id {
                     Some(sid) => Task::perform(
                         firmium_backend::commands::playlists::push_delete(self.backend.app_state.clone(), sid),

--- a/desktop/src/app/update/podcasts.rs
+++ b/desktop/src/app/update/podcasts.rs
@@ -88,6 +88,11 @@ impl App {
                 Task::none()
             }
             Message::UnsubscribePodcastChannel(channel_id) => {
+                if self.view == View::PodcastDetail(channel_id.clone()) {
+                    self.view = View::Podcasts;
+                }
+                self.nav_stack.retain(|v| *v != View::PodcastDetail(channel_id.clone()));
+                self.forward_stack.retain(|v| *v != View::PodcastDetail(channel_id.clone()));
                 if let Some(store) = self.backend.podcasts.clone() {
                     Task::perform(
                         async move { firmium_backend::podcasts::unsubscribe(store, channel_id) },


### PR DESCRIPTION
Adds support for the mouse's side back/forward buttons (plus a forward stack so you can navigate forward again after going back).

* New Message::NavigateForward alongside the existing NavigateBack. They both now share the same per-view data-loading path that Navigate uses, so returning to a view via mouse button shows the same content a direct click would.
* Raw mouse button events are picked up via iced::event::listen_with in subscription.rs, these are mapped to mouse::Button::Back/Forward.
* If a modal overlay (add-to-playlist, create-playlist, account switcher, add-podcast) is open, the mouse buttons close it first instead of navigating underneath it (same priority order as the existing Escape-key handling).
*  nav_stack/forward_stack are cleared on logout, and pruned of stale entries when a local playlist is deleted or a podcast channel is unsubscribed, so back/forward can't land on a phantom page for something that no longer exists.

No behavior change for direct navigation, this only adds new ways to move through history you've already visited.

It's been tested locally successfully through:
* cargo build --workspace
* cargo test --workspace
* cargo clippy --all-targets --all-features -- -D warnings
* cargo run -p firmium
* Manual testing

No crashes or errors were found locally.