### PR TITLE
Android: change network security config to allow user certs

### DIFF
--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -9,7 +9,7 @@
 <network-security-config>
     <base-config cleartextTrafficPermitted="true">
         <trust-anchors>
-            <certificates src="system" />
+            <certificates src="user" />
         </trust-anchors>
     </base-config>
 </network-security-config>


### PR DESCRIPTION
Since this app requires a self-hosted music server (obviously), I think it could be a common(?) issue (and was one that I ran into) that users will deploy a local certificate authority to allow secure connection to LAN services.

This change allows the app to access the user CA store on Android so HTTPS can be enforced on the server connection, even if the server only offers a locally-signed certificate.