### PR TITLE
Add sort settings to the Albums view

### DIFF
--- a/backend/commands/subsonic.rs
+++ b/backend/commands/subsonic.rs
@@ -153,7 +153,7 @@ pub async fn validate_connection(state: Arc<AppState>) -> Result<(), crate::erro
 
 const API_PAGE_SIZE: &str = "500";
 
-pub async fn get_albums(state: Arc<AppState>) -> Result<Vec<Album>, crate::errors::UserError> {
+pub async fn get_albums(state: Arc<AppState>, sort_param: &str) -> Result<Vec<Album>, crate::errors::UserError> {
     let page_size: u32 = API_PAGE_SIZE.parse().unwrap_or(500);
     let mut all = Vec::new();
     let mut offset: u32 = 0;
@@ -161,7 +161,7 @@ pub async fn get_albums(state: Arc<AppState>) -> Result<Vec<Album>, crate::error
         let body = subsonic_request(
             &state,
             "getAlbumList2",
-            &[("type", "alphabeticalByName".to_string()), ("size", page_size.to_string()), ("offset", offset.to_string())],
+            &[("type", sort_param.to_string()), ("size", page_size.to_string()), ("offset", offset.to_string())],
             false,
         )
         .await?;

--- a/desktop/src/app/message.rs
+++ b/desktop/src/app/message.rs
@@ -5,6 +5,7 @@ use firmium_backend::config::SavedAccount;
 use firmium_backend::errors::UserError;
 use firmium_backend::events::BackendEvent;
 use firmium_backend::podcasts::{PodcastChannel, PodcastEpisode};
+use crate::app::types::AlbumsSort;
 use crate::viz::VizMode;
 use crate::viz::config::{
     BarsGradientMode, BarsGradientOrientation, BarsPeakGradientMode, BarsPeakMode, GradientMode,
@@ -48,6 +49,7 @@ pub enum Message {
     PlaylistTracksLoaded(Result<PlaylistTracks, UserError>),
     CoverLoaded(String, Result<String, String>),
     AlbumsScrolled(f32),
+    AlbumsSortChanged(AlbumsSort),
     ArtistsScrolled(f32),
     AlbumTracksScrolled(f32),
     PlaylistTracksScrolled(f32),

--- a/desktop/src/app/mod.rs
+++ b/desktop/src/app/mod.rs
@@ -61,6 +61,7 @@ pub struct App {
     // ── Library data ──────────────────────────────────────────────────────────
     albums: Vec<Album>,
     albums_scroll: f32,
+    albums_sort: types::AlbumsSort,
     home_recent: Vec<Album>,
     home_newest: Vec<Album>,
     home_random: Vec<Album>,
@@ -290,6 +291,7 @@ impl App {
             nav_stack: Vec::new(),
             albums: Vec::new(),
             albums_scroll: 0.0,
+            albums_sort: types::AlbumsSort::Newest,
             home_recent: Vec::new(),
             home_newest: Vec::new(),
             home_random: Vec::new(),

--- a/desktop/src/app/types.rs
+++ b/desktop/src/app/types.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use firmium_backend::{commands::mappers::Album, errors::UserError};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -150,6 +152,18 @@ pub(crate) enum AlbumsSort {
 }
 
 impl AlbumsSort {
+    pub(crate) fn get_items() -> Vec<AlbumsSort> {
+        return vec![
+            AlbumsSort::Random,
+            AlbumsSort::Newest,
+            AlbumsSort::Frequent,
+            AlbumsSort::Recent,
+            AlbumsSort::Starred,
+            AlbumsSort::AlphabeticalByName,
+            AlbumsSort::AlphabeticalByArtist,
+        ];
+    }
+
     pub(crate) fn get_sort_param(self) -> &'static str {
         match self {
             AlbumsSort::Random => "random",
@@ -160,5 +174,19 @@ impl AlbumsSort {
             AlbumsSort::AlphabeticalByName => "alphabeticalByName",
             AlbumsSort::AlphabeticalByArtist => "alphabeticalByArtist",
         }
+    }
+}
+
+impl fmt::Display for AlbumsSort {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", match *self {
+            AlbumsSort::Random => "Random",
+            AlbumsSort::Newest => "Recently Added",
+            AlbumsSort::Frequent => "Frequent",
+            AlbumsSort::Recent => "Recent",
+            AlbumsSort::Starred => "Starred",
+            AlbumsSort::AlphabeticalByName => "A-Z (name)",
+            AlbumsSort::AlphabeticalByArtist => "A-Z (artist)",
+        })
     }
 }

--- a/desktop/src/app/types.rs
+++ b/desktop/src/app/types.rs
@@ -1,4 +1,4 @@
-use firmium_backend::errors::UserError;
+use firmium_backend::{commands::mappers::Album, errors::UserError};
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum View {
@@ -135,4 +135,30 @@ pub(crate) struct Toast {
     pub category: UserError,
     pub text: String,
     pub spawned: std::time::Instant,
+}
+
+/// Album sort options, referenced from Subsonic API getAlbumList2
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AlbumsSort {
+    Random,
+    Newest,
+    Frequent,
+    Recent,
+    Starred,
+    AlphabeticalByName,
+    AlphabeticalByArtist,
+}
+
+impl AlbumsSort {
+    pub(crate) fn get_sort_param(self) -> &'static str {
+        match self {
+            AlbumsSort::Random => "random",
+            AlbumsSort::Newest => "newest",
+            AlbumsSort::Frequent => "frequent",
+            AlbumsSort::Recent => "recent",
+            AlbumsSort::Starred => "starred",
+            AlbumsSort::AlphabeticalByName => "alphabeticalByName",
+            AlbumsSort::AlphabeticalByArtist => "alphabeticalByArtist",
+        }
+    }
 }

--- a/desktop/src/app/update/auth.rs
+++ b/desktop/src/app/update/auth.rs
@@ -75,7 +75,7 @@ impl App {
                 let cover_task = self.load_cover_ids(play_cover_ids);
                 let s = self.backend.app_state.clone();
                 Task::batch([
-                    Task::perform(firmium_backend::commands::subsonic::get_albums(s.clone()), Message::AlbumsLoaded),
+                    Task::perform(firmium_backend::commands::subsonic::get_albums(s.clone(), self.albums_sort.get_sort_param()), Message::AlbumsLoaded),
                     Task::perform(firmium_backend::commands::subsonic::get_recent_albums(s.clone(), 12), |r| Message::HomeAlbumsLoaded(HomeSection::Recent, r)),
                     Task::perform(firmium_backend::commands::subsonic::get_newest_albums(s.clone(), 12), |r| Message::HomeAlbumsLoaded(HomeSection::Newest, r)),
                     Task::perform(firmium_backend::commands::subsonic::get_random_albums(s.clone(), 12), |r| Message::HomeAlbumsLoaded(HomeSection::Random, r)),

--- a/desktop/src/app/update/library.rs
+++ b/desktop/src/app/update/library.rs
@@ -48,6 +48,12 @@ impl App {
                     .collect();
                 self.load_cover_ids(ids)
             }
+            Message::AlbumsSortChanged(sort) => {
+                self.albums_sort = sort;
+                let s = self.backend.app_state.clone();
+
+                Task::perform(firmium_backend::commands::subsonic::get_albums(s, self.albums_sort.get_sort_param()), Message::AlbumsLoaded)
+            }
             Message::ArtistsScrolled(y) => {
                 self.artists_scroll = y;
                 Task::none()

--- a/desktop/src/app/update/mod.rs
+++ b/desktop/src/app/update/mod.rs
@@ -35,6 +35,7 @@ impl App {
             | Message::HomeAlbumsLoaded(..)
             | Message::CoverLoaded(..)
             | Message::AlbumsScrolled(..)
+            | Message::AlbumsSortChanged(..)
             | Message::ArtistsScrolled(..)
             | Message::AlbumTracksScrolled(..)
             | Message::AlbumTracksLoaded(..)

--- a/desktop/src/app/view/albums.rs
+++ b/desktop/src/app/view/albums.rs
@@ -1,4 +1,4 @@
-use iced::widget::{button, column, container, row, scrollable, text};
+use iced::widget::{button, column, container, pick_list, row, scrollable, text};
 use iced::{Alignment, Background, Border, Element, Length};
 
 use firmium_backend::commands::mappers::{Album, Song};
@@ -15,6 +15,10 @@ impl App {
     pub(crate) fn album_list_view(&self) -> Element<'_, Message> {
         let t = self.tokens;
         let header = page_header(format!("Albums ({})", self.albums.len()), t, self.ui_theme_id == "spotify");
+
+        let album_sort_selector: Element<'_, Message> = pick_list(AlbumsSort::get_items(), Some(self.albums_sort), Message::AlbumsSortChanged)
+        .width(Length::Fixed(180.0))
+        .into();
 
         // Windowed (virtual) rendering: only the visible rows are built; the
         // scrolled-past and remaining heights are filled with spacers so the
@@ -35,7 +39,7 @@ impl App {
             .height(Length::Fill)
             .on_scroll(|v| Message::AlbumsScrolled(v.absolute_offset().y));
 
-        column![header, scroller].spacing(16).into()
+        column![row![header, album_sort_selector].spacing(16), scroller].spacing(16).into()
     }
 
     pub(crate) fn album_row(&self, album: &Album) -> Element<'_, Message> {


### PR DESCRIPTION
Resolves #65 

Allows supplying an arbitrary "type" arg to the Subsonic get albums request, hooks into new dropdown element on the Albums view page, and re-fetches Albums whenever the sort is changed

Screenshot: 
<img width="934" height="459" alt="image" src="https://github.com/user-attachments/assets/69428e34-fa90-42fa-a93c-58a344a5bb3a" />
