### PR TITLE
feat(android): pause playback when audio output becomes noisy

### DIFF
--- a/android/app/src/main/java/com/fossisawesome/firmium/audio/NoisyAudioReceiver.kt
+++ b/android/app/src/main/java/com/fossisawesome/firmium/audio/NoisyAudioReceiver.kt
@@ -1,0 +1,14 @@
+package com.fossisawesome.firmium.audio
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.media.AudioManager
+
+class NoisyAudioReceiver(private val controller: PlaybackController) : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == AudioManager.ACTION_AUDIO_BECOMING_NOISY) {
+            controller.pause()
+        }
+    }
+}

--- a/android/app/src/main/java/com/fossisawesome/firmium/audio/NowPlayingService.kt
+++ b/android/app/src/main/java/com/fossisawesome/firmium/audio/NowPlayingService.kt
@@ -3,7 +3,11 @@ package com.fossisawesome.firmium.audio
 import android.app.Notification
 import android.app.Service
 import android.content.Intent
+import android.content.IntentFilter
+import android.media.AudioManager
 import android.os.IBinder
+import androidx.core.content.ContextCompat
+import com.fossisawesome.firmium.FirmiumApplication
 
 // Foreground service that keeps the Now Playing notification alive when the app is backgrounded.
 // Uses the pendingNotification static set by NowPlayingController to avoid the 5s ANR timeout.
@@ -16,6 +20,26 @@ class NowPlayingService : Service() {
         const val EXTRA_NOTIFICATION = "notification"
         @Volatile
         var pendingNotification: Notification? = null
+    }
+
+    private var noisyReceiver: NoisyAudioReceiver? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        val controller = (application as FirmiumApplication).playback
+        noisyReceiver = NoisyAudioReceiver(controller)
+        ContextCompat.registerReceiver(
+            this,
+            noisyReceiver,
+            IntentFilter(AudioManager.ACTION_AUDIO_BECOMING_NOISY),
+            ContextCompat.RECEIVER_NOT_EXPORTED,
+        )
+    }
+
+    override fun onDestroy() {
+        noisyReceiver?.let { unregisterReceiver(it) }
+        noisyReceiver = null
+        super.onDestroy()
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {


### PR DESCRIPTION
## Summary

Pauses playback automatically when the audio output becomes noisy — i.e. when headphones are unplugged or a Bluetooth audio device disconnects.

This matches the behaviour described in the Android docs for [`ACTION_AUDIO_BECOMING_NOISY`](https://developer.android.com/reference/android/media/AudioManager#ACTION_AUDIO_BECOMING_NOISY) and is the standard way to avoid blasting audio through the speaker unexpectedly.

### Changes

**`NoisyAudioReceiver.kt`** (new)
- `BroadcastReceiver` that listens for `AudioManager.ACTION_AUDIO_BECOMING_NOISY`.
- Calls `PlaybackController.pause()` on receipt.

**`NowPlayingService.kt`**
- Registers `NoisyAudioReceiver` in `onCreate()` with `RECEIVER_NOT_EXPORTED` (the intent is always system-delivered, so the flag has no practical effect, but is required on API 33+).
- Unregisters in `onDestroy()`.
- Registration is on the foreground service so it remains active while the app is backgrounded.

### Testing
- Play a track with wired headphones → unplug → playback pauses.
- Play a track with Bluetooth → disconnect the device → playback pauses.
- Pause, then unplug → stays paused (no state change).