### PR TITLE
feat(android): swipe-right to queue + long-press context menu on track rows

### DIFF
--- a/android/app/src/main/java/com/fossisawesome/firmium/audio/PlaybackController.kt
+++ b/android/app/src/main/java/com/fossisawesome/firmium/audio/PlaybackController.kt
@@ -258,6 +258,35 @@ class PlaybackController(
         }
     }
 
+    // Inserts a track immediately after the currently playing item ("play next").
+    fun addNextInQueue(song: Song) {
+        val pid = currentPlayerId
+        if (pid == null || _state.value.queue.isEmpty()) {
+            playAt(listOf(song), 0)
+            return
+        }
+        scope.launch {
+            try {
+                val s = _state.value
+                val insertAt = s.queueIndex + 1
+                val rgEnabled = s.replayGainEnabled
+                audioPlayer.appendToQueue(pid, QueueTrack(
+                    streamUrl = streamUrlFor(song),
+                    trackId = song.id,
+                    replayGainDb = if (rgEnabled) (song.replayGainTrack ?: song.replayGainAlbum)?.toFloat() else null,
+                ))
+                val endIndex = s.queue.size
+                if (insertAt < endIndex) audioPlayer.moveQueueItem(pid, endIndex, insertAt)
+                val newQueue = s.queue.toMutableList().apply { add(insertAt, song) }
+                _state.update { it.copy(queue = newQueue) }
+                nowPlaying.setQueue(newQueue.map {
+                    NowPlayingController.QueueEntry(it.id, it.title, it.displayArtist ?: it.artist,
+                        it.coverArt?.let { c -> if (c.startsWith("file://")) c else auth.coverArtUrl(c, 512) })
+                })
+            } catch (_: Exception) {}
+        }
+    }
+
     // Reorders a track within the live queue (drag-to-reorder / move up-down in the queue sheet).
     fun moveQueueItem(from: Int, to: Int) {
         val pid = currentPlayerId ?: return

--- a/android/app/src/main/java/com/fossisawesome/firmium/ui/components/FirmiumUi.kt
+++ b/android/app/src/main/java/com/fossisawesome/firmium/ui/components/FirmiumUi.kt
@@ -7,13 +7,17 @@ import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.QueueMusic
 import androidx.compose.runtime.*
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.Alignment
@@ -26,6 +30,8 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
@@ -34,9 +40,12 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import com.fossisawesome.firmium.ui.theme.LocalFirmiumColors
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
 
 // Convenience Text composable backed by BasicText — replaces material3 Text() throughout the app.
 // Only supports parameters actually used in this codebase.
@@ -306,6 +315,103 @@ fun FirmiumTextButton(
         contentAlignment = Alignment.Center,
         content = { content() },
     )
+}
+
+// Swipe-right to add a song to the play queue.
+// As the user drags right, the theme accent colour is revealed behind the row and a QueueMusic
+// icon fades in. Releasing past 35% of the row width triggers the action; releasing earlier
+// springs the row back without doing anything.
+@Composable
+fun SwipeToQueueBox(
+    onAddToQueue: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    val colors = LocalFirmiumColors.current
+    val haptic = LocalHapticFeedback.current
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val offsetX = remember { Animatable(0f) }
+    var widthPx by remember { mutableFloatStateOf(1f) }
+    val threshold = 0.35f
+
+    val accentColor = colors.accent
+    Box(modifier = modifier.onSizeChanged { widthPx = it.width.toFloat().coerceAtLeast(1f) }) {
+        val revealFraction = (offsetX.value / widthPx).coerceIn(0f, 1f)
+        // Canvas draws only the revealed strip. Using a nested Box with matchParentSize() +
+        // fillMaxWidth(fraction) doesn't work: matchParentSize() sets min == parent width so
+        // fillMaxWidth(0f) can't shrink it — the background was always full-width. Canvas draws
+        // exactly what we ask.
+        Canvas(modifier = Modifier.matchParentSize()) {
+            drawRect(
+                color = accentColor.copy(alpha = 0.35f),
+                size = androidx.compose.ui.geometry.Size(size.width * revealFraction, size.height),
+            )
+        }
+        if (revealFraction > 0.12f) {
+            Box(
+                modifier = Modifier.matchParentSize(),
+                contentAlignment = Alignment.CenterStart,
+            ) {
+                FirmiumIcon(
+                    Icons.AutoMirrored.Filled.QueueMusic,
+                    contentDescription = null,
+                    tint = colors.bg.copy(alpha = ((revealFraction - 0.12f) * 5f).coerceIn(0f, 1f)),
+                    modifier = Modifier.padding(start = 16.dp).size(22.dp),
+                )
+            }
+        }
+
+        // Content offset by the drag amount.
+        Box(
+            modifier = Modifier
+                .offset { IntOffset(offsetX.value.roundToInt(), 0) }
+                .pointerInput(Unit) {
+                    detectHorizontalDragGestures(
+                        onDragEnd = {
+                            scope.launch {
+                                if (offsetX.value >= widthPx * threshold) {
+                                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                    onAddToQueue()
+                                    android.widget.Toast.makeText(
+                                        context,
+                                        "Added to queue",
+                                        android.widget.Toast.LENGTH_SHORT,
+                                    ).show()
+                                }
+                                offsetX.animateTo(
+                                    0f,
+                                    spring(
+                                        dampingRatio = Spring.DampingRatioMediumBouncy,
+                                        stiffness = Spring.StiffnessMedium,
+                                    ),
+                                )
+                            }
+                        },
+                        onDragCancel = {
+                            scope.launch {
+                                offsetX.animateTo(
+                                    0f,
+                                    spring(
+                                        dampingRatio = Spring.DampingRatioMediumBouncy,
+                                        stiffness = Spring.StiffnessMedium,
+                                    ),
+                                )
+                            }
+                        },
+                        onHorizontalDrag = { change, dragAmount ->
+                            change.consume()
+                            val capped = (offsetX.value + dragAmount)
+                                .coerceAtLeast(0f)
+                                .coerceAtMost(widthPx * 0.6f)
+                            scope.launch { offsetX.snapTo(capped) }
+                        },
+                    )
+                },
+        ) {
+            content()
+        }
+    }
 }
 
 // Thin vertical scroll-position indicator for verticalScroll() containers (no built-in scrollbar).

--- a/android/app/src/main/java/com/fossisawesome/firmium/ui/components/PlayerBar.kt
+++ b/android/app/src/main/java/com/fossisawesome/firmium/ui/components/PlayerBar.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.QueueMusic
 import androidx.compose.material.icons.filled.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -33,12 +34,13 @@ fun PlayerBar(
     onShuffleToggle: () -> Unit,
     onRepeatCycle: () -> Unit,
     onToggleStar: () -> Unit = {},
+    onQueueOpen: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     if (LocalUiTheme.current == "spotify") {
         PlayerBarSpotify(state, coverUrl, onBarClick, onPlayPause, onNext, onToggleStar, modifier)
     } else {
-        PlayerBarDefault(state, coverUrl, onBarClick, onPlayPause, onNext, onShuffleToggle, onRepeatCycle, modifier)
+        PlayerBarDefault(state, coverUrl, onBarClick, onPlayPause, onNext, onShuffleToggle, onRepeatCycle, onQueueOpen, modifier)
     }
 }
 
@@ -51,6 +53,7 @@ private fun PlayerBarDefault(
     onNext: () -> Unit,
     onShuffleToggle: () -> Unit,
     onRepeatCycle: () -> Unit,
+    onQueueOpen: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     val track = state.currentTrack ?: return
@@ -144,6 +147,12 @@ private fun PlayerBarDefault(
                 if (state.repeatMode == "one") {
                     Text("1", fontSize = 9.sp, color = colors.accent, fontWeight = FontWeight.Bold,
                         modifier = Modifier.offset(x = (-6).dp, y = 4.dp))
+                }
+            }
+            if (onQueueOpen != null) {
+                FirmiumIconButton(onClick = onQueueOpen, modifier = Modifier.size(44.dp)) {
+                    FirmiumIcon(Icons.AutoMirrored.Filled.QueueMusic, contentDescription = "Queue",
+                        tint = colors.muted, modifier = Modifier.size(18.dp))
                 }
             }
         }

--- a/android/app/src/main/java/com/fossisawesome/firmium/ui/navigation/AppNavGraph.kt
+++ b/android/app/src/main/java/com/fossisawesome/firmium/ui/navigation/AppNavGraph.kt
@@ -316,6 +316,7 @@ fun AppNavGraph(
                         onArtistClick = { navController.navigate("artist/$it") },
                         onPlaySong = { song -> playerViewModel.playAt(listOf(song), 0) },
                         onToggleSongStar = { libraryViewModel.toggleSongStar(it) },
+                        onAddToQueue = { song -> playerViewModel.addToQueue(song) },
                         onBack = { navController.popBackStack() },
                     )
                 }
@@ -376,6 +377,7 @@ fun AppNavGraph(
                         onArtistClick = { navController.navigate("artist/$it") },
                         onToggleAlbumStar = { libraryViewModel.toggleAlbumStar(it) },
                         onToggleSongStar = { libraryViewModel.toggleSongStar(it) },
+                        onAddToQueue = { song -> playerViewModel.addToQueue(song) },
                         onBack = { navController.popBackStack() },
                     )
                 }
@@ -460,6 +462,7 @@ fun AppNavGraph(
                                 onMoveTrack = { from, to -> playlistViewModel.moveServerTrack(serverId, from, to) },
                                 onDownloadTrack = onDownloadTrack,
                                 downloadedSongIds = dlIds,
+                                onAddToQueue = { song -> playerViewModel.addToQueue(song) },
                                 onBack = { navController.popBackStack() },
                             )
                         }
@@ -476,6 +479,7 @@ fun AppNavGraph(
                                 onMoveTrack = { from, to -> playlistViewModel.moveTrack(id, from, to) },
                                 onDownloadTrack = onDownloadTrack,
                                 downloadedSongIds = dlIds,
+                                onAddToQueue = { song -> playerViewModel.addToQueue(song) },
                                 onBack = { navController.popBackStack() },
                             )
                         }
@@ -622,6 +626,7 @@ fun AppNavGraph(
                         "none" -> "all"; "all" -> "one"; else -> "none"
                     })
                 },
+                onQueueOpen = { showQueue = true },
             )
         }
 

--- a/android/app/src/main/java/com/fossisawesome/firmium/ui/screens/AlbumDetailScreen.kt
+++ b/android/app/src/main/java/com/fossisawesome/firmium/ui/screens/AlbumDetailScreen.kt
@@ -1,14 +1,17 @@
 package com.fossisawesome.firmium.ui.screens
 import com.fossisawesome.firmium.ui.theme.LocalAppFontFamily
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.QueueMusic
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.KeyboardArrowDown
@@ -49,12 +52,14 @@ fun AlbumDetailScreen(
     onArtistClick: (String) -> Unit = {},
     onToggleAlbumStar: (String) -> Unit = {},
     onToggleSongStar: (Song) -> Unit = {},
+    onAddToQueue: ((Song) -> Unit)? = null,
     onBack: () -> Unit,
 ) {
     LaunchedEffect(albumId) { onLoad(albumId) }
 
     var pendingSong by remember { mutableStateOf<Song?>(null) }
     var pendingAllSongs by remember { mutableStateOf(false) }
+    var longPressSong by remember { mutableStateOf<Song?>(null) }
     val colors = LocalFirmiumColors.current
     var selectedBpm by remember { mutableIntStateOf(0) }
 
@@ -218,6 +223,8 @@ fun AlbumDetailScreen(
                             onDownloadClick = onDownloadTrack?.invoke(song),
                             isDownloaded = song.id in state.downloadedSongIds,
                             onToggleStar = { onToggleSongStar(song) },
+                            onAddToQueue = onAddToQueue?.let { { it(song) } },
+                            onLongPress = if (onAddToQueue != null) { { longPressSong = song } } else null,
                         )
                         FirmiumDivider()
                     }
@@ -244,9 +251,51 @@ fun AlbumDetailScreen(
             onDismiss = { pendingAllSongs = false },
         )
     }
+
+    longPressSong?.let { song ->
+        val colors = LocalFirmiumColors.current
+        FirmiumBottomSheet(onDismiss = { longPressSong = null }) {
+            Text(
+                song.title,
+                fontSize = 12.sp,
+                fontFamily = LocalAppFontFamily.current,
+                color = colors.muted,
+                maxLines = 1,
+                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                modifier = androidx.compose.ui.Modifier.padding(horizontal = 20.dp, vertical = 10.dp),
+            )
+            FirmiumDivider()
+            Row(
+                modifier = androidx.compose.ui.Modifier
+                    .fillMaxWidth()
+                    .clickable {
+                        onAddToQueue?.invoke(song)
+                        longPressSong = null
+                    }
+                    .padding(horizontal = 20.dp, vertical = 14.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                FirmiumIcon(
+                    Icons.AutoMirrored.Filled.QueueMusic,
+                    contentDescription = null,
+                    tint = colors.accent,
+                    modifier = androidx.compose.ui.Modifier.size(20.dp),
+                )
+                Text(
+                    "Add to queue",
+                    fontSize = 14.sp,
+                    fontFamily = LocalAppFontFamily.current,
+                    color = colors.text,
+                )
+            }
+            Spacer(androidx.compose.ui.Modifier.height(8.dp))
+        }
+    }
 }
 
 // Track row with thumbnail, title, optional artist, duration, and a visible + add button.
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun AlbumTrackRow(
     track: Song,
@@ -257,10 +306,19 @@ private fun AlbumTrackRow(
     onDownloadClick: (suspend () -> Result<Unit>)? = null,
     isDownloaded: Boolean = false,
     onToggleStar: () -> Unit = {},
+    onAddToQueue: (() -> Unit)? = null,
+    onLongPress: (() -> Unit)? = null,
 ) {
     val colors = LocalFirmiumColors.current
-    Row(
-        modifier = Modifier.fillMaxWidth().clickable { onClick() }
+    val rowContent: @Composable () -> Unit = {
+        Row(
+        modifier = Modifier.fillMaxWidth()
+            .then(
+                if (onLongPress != null)
+                    Modifier.combinedClickable(onClick = onClick, onLongClick = onLongPress)
+                else
+                    Modifier.clickable { onClick() }
+            )
             .padding(horizontal = 12.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(10.dp),
@@ -297,9 +355,16 @@ private fun AlbumTrackRow(
             FirmiumIcon(Icons.Default.Add, contentDescription = "Add to playlist", tint = colors.muted, modifier = Modifier.size(18.dp))
         }
     }
+    }   // close rowContent lambda
+    if (onAddToQueue != null) {
+        SwipeToQueueBox(onAddToQueue = onAddToQueue) { rowContent() }
+    } else {
+        rowContent()
+    }
 }
 
-// Shared TrackRow used by PlaylistDetailScreen
+// Shared TrackRow used by PlaylistDetailScreen and FavoritesScreen.
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun TrackRow(
     track: Song,
@@ -314,10 +379,20 @@ fun TrackRow(
     canMoveDown: Boolean = false,
     onRemove: (() -> Unit)? = null,
     onToggleStar: (() -> Unit)? = null,
+    onAddToQueue: (() -> Unit)? = null,
+    onLongPress: (() -> Unit)? = null,
 ) {
     val colors = LocalFirmiumColors.current
+    val rowContent: @Composable () -> Unit = {
     Row(
-        modifier = Modifier.fillMaxWidth().clickable { onClick() }.padding(horizontal = 16.dp, vertical = 10.dp),
+        modifier = Modifier.fillMaxWidth()
+            .then(
+                if (onLongPress != null)
+                    Modifier.combinedClickable(onClick = onClick, onLongClick = onLongPress)
+                else
+                    Modifier.clickable { onClick() }
+            )
+            .padding(horizontal = 16.dp, vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         if (index != null) {
@@ -367,6 +442,12 @@ fun TrackRow(
                     tint = colors.error, modifier = Modifier.size(18.dp))
             }
         }
+    }
+    }   // close rowContent lambda
+    if (onAddToQueue != null) {
+        SwipeToQueueBox(onAddToQueue = onAddToQueue) { rowContent() }
+    } else {
+        rowContent()
     }
 }
 

--- a/android/app/src/main/java/com/fossisawesome/firmium/ui/screens/FavoritesScreen.kt
+++ b/android/app/src/main/java/com/fossisawesome/firmium/ui/screens/FavoritesScreen.kt
@@ -8,8 +8,14 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.background
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.QueueMusic
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -32,10 +38,12 @@ fun FavoritesScreen(
     onArtistClick: (String) -> Unit,
     onPlaySong: (Song) -> Unit,
     onToggleSongStar: (Song) -> Unit,
+    onAddToQueue: ((Song) -> Unit)? = null,
     onBack: () -> Unit,
 ) {
     LaunchedEffect(Unit) { onLoad() }
     val colors = LocalFirmiumColors.current
+    var longPressSong by remember { mutableStateOf<Song?>(null) }
 
     Column(modifier = Modifier.fillMaxSize()) {
         FirmiumDetailHeader(title = "Favorites", onBack = onBack)
@@ -82,11 +90,53 @@ fun FavoritesScreen(
                             isCurrentlyPlaying = false,
                             onClick = { onPlaySong(song) },
                             onToggleStar = { onToggleSongStar(song) },
+                            onAddToQueue = onAddToQueue?.let { { it(song) } },
+                            onLongPress = if (onAddToQueue != null) { { longPressSong = song } } else null,
                         )
                         FirmiumDivider()
                     }
                 }
             }
+        }
+    }
+
+    longPressSong?.let { song ->
+        FirmiumBottomSheet(onDismiss = { longPressSong = null }) {
+            Text(
+                song.title,
+                fontSize = 12.sp,
+                fontFamily = LocalAppFontFamily.current,
+                color = colors.muted,
+                maxLines = 1,
+                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                modifier = Modifier.padding(horizontal = 20.dp, vertical = 10.dp),
+            )
+            FirmiumDivider()
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable {
+                        onAddToQueue?.invoke(song)
+                        longPressSong = null
+                    }
+                    .padding(horizontal = 20.dp, vertical = 14.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                FirmiumIcon(
+                    Icons.AutoMirrored.Filled.QueueMusic,
+                    contentDescription = null,
+                    tint = colors.accent,
+                    modifier = Modifier.size(20.dp),
+                )
+                Text(
+                    "Add to queue",
+                    fontSize = 14.sp,
+                    fontFamily = LocalAppFontFamily.current,
+                    color = colors.text,
+                )
+            }
+            Spacer(Modifier.height(8.dp))
         }
     }
 }

--- a/android/app/src/main/java/com/fossisawesome/firmium/ui/screens/PlaylistDetailScreen.kt
+++ b/android/app/src/main/java/com/fossisawesome/firmium/ui/screens/PlaylistDetailScreen.kt
@@ -1,10 +1,12 @@
 package com.fossisawesome.firmium.ui.screens
 import com.fossisawesome.firmium.ui.theme.LocalAppFontFamily
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.QueueMusic
 import androidx.compose.material.icons.filled.DownloadDone
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.runtime.*
@@ -28,10 +30,12 @@ fun PlaylistDetailScreen(
     onMoveTrack: (from: Int, to: Int) -> Unit,
     onDownloadTrack: ((Song) -> suspend () -> Result<Unit>)? = null,
     downloadedSongIds: Set<String> = emptySet(),
+    onAddToQueue: ((Song) -> Unit)? = null,
     onBack: () -> Unit,
 ) {
     val colors = LocalFirmiumColors.current
     val allDownloaded = tracks.isNotEmpty() && downloadedSongIds.size >= tracks.size
+    var longPressSong by remember { mutableStateOf<Song?>(null) }
 
     Column(modifier = Modifier.fillMaxSize()) {
         FirmiumDetailHeader(
@@ -86,10 +90,52 @@ fun PlaylistDetailScreen(
                         canMoveUp = index > 0,
                         canMoveDown = index < tracks.size - 1,
                         onRemove = { onRemoveTrack(song.id, index) },
+                        onAddToQueue = onAddToQueue?.let { { it(song) } },
+                        onLongPress = if (onAddToQueue != null) { { longPressSong = song } } else null,
                     )
                     FirmiumDivider()
                 }
             }
+        }
+    }
+
+    longPressSong?.let { song ->
+        FirmiumBottomSheet(onDismiss = { longPressSong = null }) {
+            Text(
+                song.title,
+                fontSize = 12.sp,
+                fontFamily = LocalAppFontFamily.current,
+                color = colors.muted,
+                maxLines = 1,
+                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                modifier = Modifier.padding(horizontal = 20.dp, vertical = 10.dp),
+            )
+            FirmiumDivider()
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable {
+                        onAddToQueue?.invoke(song)
+                        longPressSong = null
+                    }
+                    .padding(horizontal = 20.dp, vertical = 14.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                FirmiumIcon(
+                    Icons.AutoMirrored.Filled.QueueMusic,
+                    contentDescription = null,
+                    tint = colors.accent,
+                    modifier = Modifier.size(20.dp),
+                )
+                Text(
+                    "Add to queue",
+                    fontSize = 14.sp,
+                    fontFamily = LocalAppFontFamily.current,
+                    color = colors.text,
+                )
+            }
+            Spacer(Modifier.height(8.dp))
         }
     }
 }

--- a/android/app/src/main/java/com/fossisawesome/firmium/viewmodel/PlayerViewModel.kt
+++ b/android/app/src/main/java/com/fossisawesome/firmium/viewmodel/PlayerViewModel.kt
@@ -82,6 +82,7 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
     }
     fun skipToIndex(index: Int) = controller.skipToIndex(index)
     fun addToQueue(song: Song) = controller.addToQueue(song)
+    fun addNextInQueue(song: Song) = controller.addNextInQueue(song)
     fun moveQueueItem(from: Int, to: Int) = controller.moveQueueItem(from, to)
     fun removeQueueItem(index: Int) = controller.removeQueueItem(index)
     fun pause() = controller.pause()


### PR DESCRIPTION
## Summary

Two complementary shortcuts to add a song to the play queue from any track list (album, playlist, favorites), without opening the full-screen player.

---

### 1 — `SwipeToQueueBox` — swipe-right gesture

A new `SwipeToQueueBox` composable in `FirmiumUi.kt` wraps a track row in a horizontal drag gesture:

- Dragging right slides the row content and **reveals a strip of the theme accent colour** sized exactly to the drag distance.
  - Implemented with `Canvas` + `drawRect(size = Size(width × fraction, height))` rather than `Box + fillMaxWidth(fraction)`. The Box approach does not work inside `LazyColumn` because `matchParentSize()` sets a minimum constraint equal to the parent width, so `fillMaxWidth(0f)` cannot shrink the background to zero — the coloured strip was always visible even without swiping. The Canvas approach draws exactly what is requested.
- A `QueueMusic` icon fades in once the strip is wide enough.
- Releasing **past 35 %** of the row width triggers `onAddToQueue()`, fires haptic feedback (`LongPress` type), shows a brief "Added to queue" Toast, and springs the row back.
- Releasing earlier springs back without action.
- Vertical scroll is unaffected — `detectHorizontalDragGestures` correctly defers to `LazyColumn`'s scroll when the gesture is primarily vertical.

### 2 — Long-press bottom sheet

- `combinedClickable` replaces `clickable` on track rows when `onLongPress` is provided.
- Long-pressing opens a `FirmiumBottomSheet` with a single **"Add to queue"** action.
- Sheet state is held at the parent screen level (outside `LazyColumn`) to avoid `fillMaxSize` / clip conflicts inside lazy items.

### Wire-up

Both features are **opt-in via nullable lambdas** — screens that do not pass `onAddToQueue` are completely unaffected. `AlbumDetailScreen`, `PlaylistDetailScreen`, `FavoritesScreen`, and `AppNavGraph` are all wired up.

### This PR also includes (as a base)

- `PlaybackController.addNextInQueue(song)` — inserts a song immediately after the current track.
- `PlayerBar` queue-open button — a `QueueMusic` icon in the mini-player that opens the queue sheet, so it is reachable without entering the full-screen player.
